### PR TITLE
LiteRt Qualcomm wrappers

### DIFF
--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/BUILD
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/BUILD
@@ -1,4 +1,5 @@
-# TODO: license
+#  Copyright (c) Qualcomm Innovation Center, Inc.
+#  All Rights Reserved.
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/BUILD
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/BUILD
@@ -15,7 +15,6 @@ cc_library(
     ],
     deps = [
         # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
-        "//third_party/qairt/latest:qnn_lib_headers",
     ],
 )
 
@@ -29,7 +28,6 @@ cc_library(
     ],
     deps = [
         # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
-        "//third_party/qairt/latest:qnn_lib_headers",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:quantize_params_wrapper",
     ],
 )
@@ -44,7 +42,6 @@ cc_library(
     ],
     deps = [
         # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
-        "//third_party/qairt/latest:qnn_lib_headers",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
     ],
 )
@@ -59,7 +56,6 @@ cc_library(
     ],
     deps = [
         # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
-        "//third_party/qairt/latest:qnn_lib_headers",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:param_wrapper",
     ],

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/BUILD
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/BUILD
@@ -1,0 +1,66 @@
+# TODO: license
+
+package(
+    # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
+    default_visibility = ["//tensorflow/lite/experimental/litert/vendors/qualcomm:__subpackages__"],
+)
+
+cc_library(
+    name = "quantize_params_wrapper",
+    srcs = ["quantize_params_wrapper.cc"],
+    hdrs = ["quantize_params_wrapper.h"],
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "nobuilder",
+    ],
+    deps = [
+        # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
+        "//third_party/qairt/latest:qnn_lib_headers",
+    ],
+)
+
+cc_library(
+    name = "tensor_wrapper",
+    srcs = ["tensor_wrapper.cc"],
+    hdrs = ["tensor_wrapper.h"],
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "nobuilder",
+    ],
+    deps = [
+        # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
+        "//third_party/qairt/latest:qnn_lib_headers",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:quantize_params_wrapper",
+    ],
+)
+
+cc_library(
+    name = "param_wrapper",
+    srcs = ["param_wrapper.cc"],
+    hdrs = ["param_wrapper.h"],
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "nobuilder",
+    ],
+    deps = [
+        # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
+        "//third_party/qairt/latest:qnn_lib_headers",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+    ],
+)
+
+cc_library(
+    name = "op_wrapper",
+    srcs = ["op_wrapper.cc"],
+    hdrs = ["op_wrapper.h"],
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "nobuilder",
+    ],
+    deps = [
+        # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
+        "//third_party/qairt/latest:qnn_lib_headers",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:param_wrapper",
+    ],
+)

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.cc
@@ -1,0 +1,73 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+
+namespace qnn {
+
+OpWrapper::OpWrapper(std::string name, const char* op_type)
+    : name_{std::move(name)} {
+  qnn_op_.v1.packageName = QNN_OP_PACKAGE_NAME_QTI_AISW;
+  qnn_op_.v1.typeName = op_type;
+  qnn_op_.v1.name = name_.c_str();
+}
+
+OpWrapper::OpWrapper(const OpWrapper& other)
+    : qnn_op_{other.qnn_op_},
+      name_{other.name_},
+      params_{other.params_},
+      input_tensors_{other.input_tensors_},
+      output_tensors_{other.output_tensors_} {
+  qnn_op_.v1.name = name_.c_str();
+  qnn_op_.v1.params = params_.data();
+  qnn_op_.v1.inputTensors = input_tensors_.data();
+  qnn_op_.v1.outputTensors = output_tensors_.data();
+}
+
+OpWrapper::OpWrapper(OpWrapper&& other)
+    : qnn_op_{other.qnn_op_},
+      name_{std::move(other.name_)},
+      params_{std::move(other.params_)},
+      input_tensors_{std::move(other.input_tensors_)},
+      output_tensors_{std::move(other.output_tensors_)} {
+  qnn_op_.v1.name = name_.c_str();
+  qnn_op_.v1.params = params_.data();
+  qnn_op_.v1.inputTensors = input_tensors_.data();
+  qnn_op_.v1.outputTensors = output_tensors_.data();
+}
+
+OpWrapper::~OpWrapper() = default;
+
+void OpWrapper::AddInputTensor(const TensorWrapper& tensor) {
+  auto& back = input_tensors_.emplace_back();
+  tensor.CloneTo(back);
+
+  qnn_op_.v1.numOfInputs = input_tensors_.size();
+  qnn_op_.v1.inputTensors = input_tensors_.data();
+}
+
+void OpWrapper::AddOutputTensor(const TensorWrapper& tensor) {
+  auto& back = output_tensors_.emplace_back();
+  tensor.CloneTo(back);
+
+  qnn_op_.v1.numOfOutputs = output_tensors_.size();
+  qnn_op_.v1.outputTensors = output_tensors_.data();
+}
+
+void OpWrapper::AddTensorParam(const char* name, const TensorWrapper& tensor) {
+  TensorParamWrapper param_wrapper(name, tensor);
+
+  auto& back = params_.emplace_back();
+  param_wrapper.CloneTo(back);
+
+  qnn_op_.v1.numOfParams = params_.size();
+  qnn_op_.v1.params = params_.data();
+}
+
+const Qnn_OpConfig_t& OpWrapper::GetOpConfig() const { return qnn_op_; }
+
+}  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.cc
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
 
 namespace qnn {

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.h
@@ -1,0 +1,57 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_WRAPPERS_OP_WRAPPER_H_
+#define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_WRAPPERS_OP_WRAPPER_H_
+
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/param_wrapper.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+#include "third_party/qairt/latest/include/QNN/QnnOpDef.h"
+
+namespace qnn {
+
+class OpWrapper final {
+ public:
+  explicit OpWrapper(std::string name, const char* op_type);
+
+  OpWrapper(const OpWrapper& other);
+
+  OpWrapper(OpWrapper&& other);
+
+  ~OpWrapper();
+
+  void AddInputTensor(const TensorWrapper& tensor);
+
+  void AddOutputTensor(const TensorWrapper& tensor);
+
+  template <typename T>
+  void AddScalarParam(const char* name, const T data,
+                      const bool is_quant = false) {
+    ScalarParamWrapper param_wrapper(name, data, is_quant);
+
+    auto& back = params_.emplace_back();
+    param_wrapper.CloneTo(back);
+
+    qnn_op_.v1.numOfParams = params_.size();
+    qnn_op_.v1.params = params_.data();
+  }
+
+  void AddTensorParam(const char* name, const TensorWrapper& tensor);
+
+  const Qnn_OpConfig_t& GetOpConfig() const;
+
+ private:
+  Qnn_OpConfig_t qnn_op_ = QNN_OPCONFIG_INIT;
+  std::string name_{};  // human readable name
+  std::vector<Qnn_Param_t> params_{};
+  std::vector<Qnn_Tensor_t> input_tensors_{};
+  std::vector<Qnn_Tensor_t> output_tensors_{};
+};
+
+}  // namespace qnn
+
+#endif  // TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_WRAPPERS_OP_WRAPPER_H_

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.h
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_WRAPPERS_OP_WRAPPER_H_
 #define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_WRAPPERS_OP_WRAPPER_H_
 

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/param_wrapper.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/param_wrapper.cc
@@ -1,0 +1,23 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/param_wrapper.h"
+
+namespace qnn {
+
+void ScalarParamWrapper::CloneTo(Qnn_Param_t& dst) const { dst = qnn_param_; }
+
+TensorParamWrapper::TensorParamWrapper(const char* name,
+                                       const TensorWrapper& tensor) {
+  qnn_param_.name = name;
+  qnn_param_.paramType = QNN_PARAMTYPE_TENSOR;
+  tensor.CloneTo(qnn_param_.tensorParam);
+}
+
+void TensorParamWrapper::CloneTo(Qnn_Param_t& dst) const { dst = qnn_param_; }
+
+}  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/param_wrapper.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/param_wrapper.cc
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/param_wrapper.h"
 
 namespace qnn {

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/param_wrapper.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/param_wrapper.h
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_WRAPPERS_PARAM_WRAPPER_H_
 #define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_WRAPPERS_PARAM_WRAPPER_H_
 

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/param_wrapper.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/param_wrapper.h
@@ -1,0 +1,78 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_WRAPPERS_PARAM_WRAPPER_H_
+#define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_WRAPPERS_PARAM_WRAPPER_H_
+
+#include <type_traits>
+
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+#include "third_party/qairt/latest/include/QNN/QnnTypes.h"
+
+namespace qnn {
+
+class ScalarParamWrapper {
+ public:
+  template <typename T>
+  explicit ScalarParamWrapper(const char* name, const T data,
+                              const bool is_quant) {
+    qnn_param_.name = name;
+    qnn_param_.paramType = QNN_PARAMTYPE_SCALAR;
+    if constexpr (std::is_same_v<T, bool>) {
+      qnn_param_.scalarParam.dataType = QNN_DATATYPE_BOOL_8;
+      qnn_param_.scalarParam.bool8Value = data;
+    } else if constexpr (std::is_same_v<T, std::uint8_t>) {
+      qnn_param_.scalarParam.dataType =
+          is_quant ? QNN_DATATYPE_UFIXED_POINT_8 : QNN_DATATYPE_UINT_8;
+      qnn_param_.scalarParam.uint8Value = data;
+    } else if constexpr (std::is_same_v<T, std::int8_t>) {
+      qnn_param_.scalarParam.dataType =
+          is_quant ? QNN_DATATYPE_SFIXED_POINT_8 : QNN_DATATYPE_INT_8;
+      qnn_param_.scalarParam.int8Value = data;
+    } else if constexpr (std::is_same_v<T, std::uint16_t>) {
+      qnn_param_.scalarParam.dataType =
+          is_quant ? QNN_DATATYPE_UFIXED_POINT_16 : QNN_DATATYPE_UINT_16;
+      qnn_param_.scalarParam.uint16Value = data;
+    } else if constexpr (std::is_same_v<T, std::int16_t>) {
+      qnn_param_.scalarParam.dataType =
+          is_quant ? QNN_DATATYPE_SFIXED_POINT_16 : QNN_DATATYPE_INT_16;
+      qnn_param_.scalarParam.int16Value = data;
+    } else if constexpr (std::is_same_v<T, std::uint32_t>) {
+      qnn_param_.scalarParam.dataType =
+          is_quant ? QNN_DATATYPE_UFIXED_POINT_32 : QNN_DATATYPE_UINT_32;
+      qnn_param_.scalarParam.uint32Value = data;
+    } else if constexpr (std::is_same_v<T, std::int32_t>) {
+      qnn_param_.scalarParam.dataType =
+          is_quant ? QNN_DATATYPE_SFIXED_POINT_32 : QNN_DATATYPE_INT_32;
+      qnn_param_.scalarParam.int32Value = data;
+    } else if constexpr (std::is_same_v<T, float>) {
+      qnn_param_.scalarParam.dataType = QNN_DATATYPE_FLOAT_32;
+      qnn_param_.scalarParam.floatValue = data;
+    } else {
+      // TODO: error log
+    }
+  }
+
+  void CloneTo(Qnn_Param_t& dst) const;
+
+ private:
+  Qnn_Param_t qnn_param_ = QNN_PARAM_INIT;
+};
+
+class TensorParamWrapper {
+ public:
+  explicit TensorParamWrapper(const char* name, const TensorWrapper& tensor);
+
+  void CloneTo(Qnn_Param_t& dst) const;
+
+ private:
+  Qnn_Param_t qnn_param_ = QNN_PARAM_INIT;
+};
+
+}  // namespace qnn
+
+#endif  // TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_WRAPPERS_PARAM_WRAPPER_H_

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.cc
@@ -1,0 +1,85 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h"
+
+#include <cassert>
+
+namespace qnn {
+
+UndefinedQuantizeParamsWrapper::UndefinedQuantizeParamsWrapper() = default;
+
+UndefinedQuantizeParamsWrapper::UndefinedQuantizeParamsWrapper(
+    const UndefinedQuantizeParamsWrapper&) = default;
+
+UndefinedQuantizeParamsWrapper::UndefinedQuantizeParamsWrapper(
+    UndefinedQuantizeParamsWrapper&&) = default;
+
+void UndefinedQuantizeParamsWrapper::CloneTo(Qnn_QuantizeParams_t& dst) {
+  dst = qnn_quantize_param_;
+}
+
+ScaleOffsetQuantizeParamsWrapper::ScaleOffsetQuantizeParamsWrapper(
+    const float scale, const std::int32_t zero_point) {
+  qnn_quantize_param_.encodingDefinition = QNN_DEFINITION_DEFINED;
+  qnn_quantize_param_.quantizationEncoding =
+      QNN_QUANTIZATION_ENCODING_SCALE_OFFSET;
+  qnn_quantize_param_.scaleOffsetEncoding.scale = scale;
+  qnn_quantize_param_.scaleOffsetEncoding.offset = -1 * zero_point;
+}
+
+ScaleOffsetQuantizeParamsWrapper::ScaleOffsetQuantizeParamsWrapper(
+    const ScaleOffsetQuantizeParamsWrapper&) = default;
+
+ScaleOffsetQuantizeParamsWrapper::ScaleOffsetQuantizeParamsWrapper(
+    ScaleOffsetQuantizeParamsWrapper&&) = default;
+
+void ScaleOffsetQuantizeParamsWrapper::CloneTo(Qnn_QuantizeParams_t& dst) {
+  dst = qnn_quantize_param_;
+}
+
+AxisScaleOffsetQuantizeParamsWrapper::AxisScaleOffsetQuantizeParamsWrapper(
+    const std::int32_t axis, const std::span<const float> scales,
+    const std::span<const std::int32_t> zero_points)
+    : scale_offsets_(scales.size()) {
+  assert(scales.size() == zero_points.size());
+  for (size_t i = 0; i < scale_offsets_.size(); ++i) {
+    scale_offsets_[i].scale = scales[i];
+    scale_offsets_[i].offset = -1 * zero_points[i];
+  }
+
+  qnn_quantize_param_.encodingDefinition = QNN_DEFINITION_DEFINED;
+  qnn_quantize_param_.quantizationEncoding =
+      QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET;
+  qnn_quantize_param_.axisScaleOffsetEncoding.axis = axis;
+  qnn_quantize_param_.axisScaleOffsetEncoding.numScaleOffsets =
+      scale_offsets_.size();
+  qnn_quantize_param_.axisScaleOffsetEncoding.scaleOffset =
+      scale_offsets_.data();
+}
+
+AxisScaleOffsetQuantizeParamsWrapper::AxisScaleOffsetQuantizeParamsWrapper(
+    const AxisScaleOffsetQuantizeParamsWrapper& rhs)
+    : qnn_quantize_param_{rhs.qnn_quantize_param_},
+      scale_offsets_{rhs.scale_offsets_} {
+  qnn_quantize_param_.axisScaleOffsetEncoding.scaleOffset =
+      scale_offsets_.data();
+}
+
+AxisScaleOffsetQuantizeParamsWrapper::AxisScaleOffsetQuantizeParamsWrapper(
+    AxisScaleOffsetQuantizeParamsWrapper&& rhs)
+    : qnn_quantize_param_{rhs.qnn_quantize_param_},
+      scale_offsets_{std::move(rhs.scale_offsets_)} {
+  qnn_quantize_param_.axisScaleOffsetEncoding.scaleOffset =
+      scale_offsets_.data();
+}
+
+void AxisScaleOffsetQuantizeParamsWrapper::CloneTo(Qnn_QuantizeParams_t& dst) {
+  dst = qnn_quantize_param_;
+}
+
+}  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.cc
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h"
 
 #include <cassert>

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_WRAPPERS_QUANTIZE_PARAMS_WRAPPER_H_
 #define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_WRAPPERS_QUANTIZE_PARAMS_WRAPPER_H_
 

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h
@@ -1,0 +1,75 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_WRAPPERS_QUANTIZE_PARAMS_WRAPPER_H_
+#define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_WRAPPERS_QUANTIZE_PARAMS_WRAPPER_H_
+
+#include <cstdint>
+#include <span>
+#include <variant>
+#include <vector>
+
+#include "third_party/qairt/latest/include/QNN/QnnTypes.h"
+
+namespace qnn {
+
+class UndefinedQuantizeParamsWrapper final {
+ public:
+  UndefinedQuantizeParamsWrapper();
+
+  UndefinedQuantizeParamsWrapper(const UndefinedQuantizeParamsWrapper&);
+
+  UndefinedQuantizeParamsWrapper(UndefinedQuantizeParamsWrapper&&);
+
+  void CloneTo(Qnn_QuantizeParams_t& dst);
+
+ private:
+  Qnn_QuantizeParams_t qnn_quantize_param_ = QNN_QUANTIZE_PARAMS_INIT;
+};
+
+class ScaleOffsetQuantizeParamsWrapper final {
+ public:
+  explicit ScaleOffsetQuantizeParamsWrapper(const float scale,
+                                            const std::int32_t zero_point);
+
+  ScaleOffsetQuantizeParamsWrapper(const ScaleOffsetQuantizeParamsWrapper&);
+
+  ScaleOffsetQuantizeParamsWrapper(ScaleOffsetQuantizeParamsWrapper&&);
+
+  void CloneTo(Qnn_QuantizeParams_t& dst);
+
+ private:
+  Qnn_QuantizeParams_t qnn_quantize_param_ = QNN_QUANTIZE_PARAMS_INIT;
+};
+
+class AxisScaleOffsetQuantizeParamsWrapper final {
+ public:
+  explicit AxisScaleOffsetQuantizeParamsWrapper(
+      const std::int32_t axis, const std::span<const float> scales,
+      const std::span<const std::int32_t> zero_points);
+
+  AxisScaleOffsetQuantizeParamsWrapper(
+      const AxisScaleOffsetQuantizeParamsWrapper& rhs);
+
+  AxisScaleOffsetQuantizeParamsWrapper(
+      AxisScaleOffsetQuantizeParamsWrapper&& rhs);
+
+  void CloneTo(Qnn_QuantizeParams_t& dst);
+
+ private:
+  Qnn_QuantizeParams_t qnn_quantize_param_ = QNN_QUANTIZE_PARAMS_INIT;
+  std::vector<Qnn_ScaleOffset_t> scale_offsets_;
+};
+
+using QuantizeParamsWrapperVariant =
+    std::variant<UndefinedQuantizeParamsWrapper,
+                 ScaleOffsetQuantizeParamsWrapper,
+                 AxisScaleOffsetQuantizeParamsWrapper>;
+
+}  // namespace qnn
+
+#endif  // TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_WRAPPERS_QUANTIZE_PARAMS_WRAPPER_H_

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.cc
@@ -15,44 +15,42 @@
 namespace qnn {
 
 std::size_t GetDataTypeSize(const Qnn_DataType_t data_type) {
-  std::size_t size = 0;
+  std::size_t bytes = 0;
   switch (data_type) {
-    case QNN_DATATYPE_SFIXED_POINT_4:
-    case QNN_DATATYPE_UFIXED_POINT_4:
-      size = 4;
-      break;
     case QNN_DATATYPE_INT_8:
     case QNN_DATATYPE_UINT_8:
     case QNN_DATATYPE_SFIXED_POINT_8:
     case QNN_DATATYPE_UFIXED_POINT_8:
     case QNN_DATATYPE_BOOL_8:
-      size = 8;
+      bytes = 1;
       break;
     case QNN_DATATYPE_INT_16:
     case QNN_DATATYPE_UINT_16:
     case QNN_DATATYPE_FLOAT_16:
     case QNN_DATATYPE_SFIXED_POINT_16:
     case QNN_DATATYPE_UFIXED_POINT_16:
-      size = 16;
+      bytes = 2;
       break;
     case QNN_DATATYPE_INT_32:
     case QNN_DATATYPE_UINT_32:
     case QNN_DATATYPE_FLOAT_32:
     case QNN_DATATYPE_SFIXED_POINT_32:
     case QNN_DATATYPE_UFIXED_POINT_32:
-      size = 32;
+      bytes = 4;
       break;
     case QNN_DATATYPE_INT_64:
     case QNN_DATATYPE_UINT_64:
     case QNN_DATATYPE_FLOAT_64:
-      size = 64;
+      bytes = 8;
       break;
     case QNN_DATATYPE_UNDEFINED:
+    case QNN_DATATYPE_SFIXED_POINT_4:
+    case QNN_DATATYPE_UFIXED_POINT_4:
     default:
-      size = 0;
+      bytes = 0;
       break;
   }
-  return size;
+  return bytes;
 }
 
 TensorWrapper::TensorWrapper() = default;
@@ -164,7 +162,7 @@ void TensorWrapper::SetTensorData(std::uint32_t bytes, const void* data) {
   }
 
   owned_data_.resize(bytes);
-  std::memcpy(owned_data_.data(), static_cast<const char*>(data), bytes);
+  std::memcpy(owned_data_.data(), reinterpret_cast<const char*>(data), bytes);
 
   qnn_tensor_.v2.clientBuf.dataSize = owned_data_.size();
   qnn_tensor_.v2.clientBuf.data = owned_data_.data();

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.cc
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
 
 #include <cmath>

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.cc
@@ -1,0 +1,218 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+#include <cmath>
+#include <cstring>
+#include <iostream>
+#include <numeric>
+
+namespace qnn {
+
+std::size_t GetDataTypeSize(const Qnn_DataType_t data_type) {
+  std::size_t size = 0;
+  switch (data_type) {
+    case QNN_DATATYPE_SFIXED_POINT_4:
+    case QNN_DATATYPE_UFIXED_POINT_4:
+      size = 4;
+      break;
+    case QNN_DATATYPE_INT_8:
+    case QNN_DATATYPE_UINT_8:
+    case QNN_DATATYPE_SFIXED_POINT_8:
+    case QNN_DATATYPE_UFIXED_POINT_8:
+    case QNN_DATATYPE_BOOL_8:
+      size = 8;
+      break;
+    case QNN_DATATYPE_INT_16:
+    case QNN_DATATYPE_UINT_16:
+    case QNN_DATATYPE_FLOAT_16:
+    case QNN_DATATYPE_SFIXED_POINT_16:
+    case QNN_DATATYPE_UFIXED_POINT_16:
+      size = 16;
+      break;
+    case QNN_DATATYPE_INT_32:
+    case QNN_DATATYPE_UINT_32:
+    case QNN_DATATYPE_FLOAT_32:
+    case QNN_DATATYPE_SFIXED_POINT_32:
+    case QNN_DATATYPE_UFIXED_POINT_32:
+      size = 32;
+      break;
+    case QNN_DATATYPE_INT_64:
+    case QNN_DATATYPE_UINT_64:
+    case QNN_DATATYPE_FLOAT_64:
+      size = 64;
+      break;
+    case QNN_DATATYPE_UNDEFINED:
+    default:
+      size = 0;
+      break;
+  }
+  return size;
+}
+
+TensorWrapper::TensorWrapper() = default;
+
+TensorWrapper::TensorWrapper(
+    std::uint32_t id, Qnn_TensorType_t tensor_type, Qnn_DataType_t data_type,
+    const QuantizeParamsWrapperVariant& quantize_params,
+    const std::vector<std::uint32_t>& dimentions)
+    : name_{std::to_string(id)},
+      dimentions_{dimentions},
+      quantize_params_{quantize_params} {
+  qnn_tensor_.v2.name = name_.c_str();
+  qnn_tensor_.v2.type = tensor_type;
+  qnn_tensor_.v2.dataFormat = QNN_TENSOR_DATA_FORMAT_FLAT_BUFFER;
+  qnn_tensor_.v2.dataType = data_type;
+  std::visit(
+      [this](auto&& quantize_params) -> void {
+        quantize_params.CloneTo(qnn_tensor_.v2.quantizeParams);
+      },
+      quantize_params_);
+  qnn_tensor_.v2.rank = dimentions_.size();
+  qnn_tensor_.v2.dimensions = dimentions_.data();
+  qnn_tensor_.v2.memType = QNN_TENSORMEMTYPE_RAW;
+}
+
+TensorWrapper::TensorWrapper(
+    std::uint32_t id, Qnn_TensorType_t tensor_type, Qnn_DataType_t data_type,
+    const QuantizeParamsWrapperVariant& quantize_params,
+    const std::vector<std::uint32_t>& dimentions, std::uint32_t bytes,
+    const void* data)
+    : TensorWrapper(id, tensor_type, data_type, quantize_params, dimentions) {
+  SetTensorData(bytes, data);
+}
+
+TensorWrapper::TensorWrapper(const TensorWrapper& other)
+    : qnn_tensor_{other.qnn_tensor_},
+      name_{other.name_},
+      dimentions_{other.dimentions_},
+      quantize_params_{other.quantize_params_},
+      owned_data_{other.owned_data_} {
+  qnn_tensor_.v2.name = name_.c_str();
+  qnn_tensor_.v2.dimensions = dimentions_.data();
+  qnn_tensor_.v2.clientBuf.data = owned_data_.data();
+  std::visit(
+      [this](auto&& quant_params) -> void {
+        quant_params.CloneTo(qnn_tensor_.v2.quantizeParams);
+      },
+      quantize_params_);
+}
+
+TensorWrapper::TensorWrapper(TensorWrapper&& other)
+    : qnn_tensor_{other.qnn_tensor_},
+      name_{std::move(other.name_)},
+      dimentions_{std::move(other.dimentions_)},
+      quantize_params_{std::move(other.quantize_params_)},
+      owned_data_{std::move(other.owned_data_)} {
+  qnn_tensor_.v2.name = name_.c_str();
+  qnn_tensor_.v2.dimensions = dimentions_.data();
+  qnn_tensor_.v2.clientBuf.data = owned_data_.data();
+  std::visit(
+      [this](auto&& quant_params) -> void {
+        quant_params.CloneTo(qnn_tensor_.v2.quantizeParams);
+      },
+      quantize_params_);
+}
+
+TensorWrapper::~TensorWrapper() = default;
+
+std::uint32_t TensorWrapper::GetDim(size_t index) const {
+  return dimentions_[index];
+}
+
+Qnn_DataType_t TensorWrapper::GetDataType() const {
+  return qnn_tensor_.v2.dataType;
+}
+
+void TensorWrapper::CloneTo(Qnn_Tensor_t& dst) const { dst = qnn_tensor_; }
+
+std::uint32_t TensorWrapper::GetRank() const { return qnn_tensor_.v2.rank; }
+
+Qnn_TensorType_t TensorWrapper::GetTensorType() const {
+  return qnn_tensor_.v2.type;
+}
+
+size_t TensorWrapper::GetTensorSize() const {
+  return std::accumulate(GetDims().begin(), GetDims().end(),
+                         GetDataTypeSize(GetDataType()), std::multiplies<>());
+}
+
+void TensorWrapper::SetDataType(Qnn_DataType_t data_type) {
+  qnn_tensor_.v2.dataType = data_type;
+}
+
+void TensorWrapper::SetTensorData(std::uint32_t bytes, const void* data) {
+  if (!IsSubgraphInput() && !IsTensorStatic()) {
+    // TODO: error log
+    // LITERT_LOG(LITERT_ERROR,
+    //            "Cannot set tensor data of tensor type other than "
+    //            "QNN_TENSOR_TYPE_APP_WRITE or QNN_TENSOR_TYPE_STATIC.");
+    return;
+  }
+
+  if (bytes != GetTensorSize()) {
+    // TODO: error log
+    std::cout << "ERROR bytes: " << bytes
+              << " != TensorSize(): " << GetTensorSize()
+              << ", use TensorSize() instead." << std::endl;
+    bytes = GetTensorSize();
+  }
+
+  owned_data_.resize(bytes);
+  std::memcpy(owned_data_.data(), static_cast<const char*>(data), bytes);
+
+  qnn_tensor_.v2.clientBuf.dataSize = owned_data_.size();
+  qnn_tensor_.v2.clientBuf.data = owned_data_.data();
+}
+
+bool TensorWrapper::IsPerTensorQuantWithOffsetDiff(
+    const TensorWrapper& rhs) const {
+  const auto& lhs_quant = qnn_tensor_.v2.quantizeParams;
+  const auto& rhs_quant = rhs.qnn_tensor_.v2.quantizeParams;
+
+  if (lhs_quant.encodingDefinition != QNN_DEFINITION_DEFINED ||
+      rhs_quant.encodingDefinition != QNN_DEFINITION_DEFINED) {
+    return false;
+  }
+
+  if (lhs_quant.quantizationEncoding !=
+          QNN_QUANTIZATION_ENCODING_SCALE_OFFSET ||
+      rhs_quant.quantizationEncoding !=
+          QNN_QUANTIZATION_ENCODING_SCALE_OFFSET) {
+    return false;
+  }
+
+  const auto lhs_scale = lhs_quant.scaleOffsetEncoding.scale;
+  const auto lhs_offset = lhs_quant.scaleOffsetEncoding.offset;
+  const auto rhs_scale = rhs_quant.scaleOffsetEncoding.scale;
+  const auto rhs_offset = rhs_quant.scaleOffsetEncoding.offset;
+  if ((GetDataType() == QNN_DATATYPE_SFIXED_POINT_8 &&
+       rhs.GetDataType() == QNN_DATATYPE_UFIXED_POINT_8) ||
+      (GetDataType() == QNN_DATATYPE_UFIXED_POINT_8 &&
+       rhs.GetDataType() == QNN_DATATYPE_SFIXED_POINT_8)) {
+    constexpr int kSUFixed8OffsetDiff = 128;
+    if (std::fabs(lhs_scale - rhs_scale) <
+            std::numeric_limits<float>::epsilon() &&
+        std::abs(lhs_offset - rhs_offset) == kSUFixed8OffsetDiff) {
+      return true;
+    }
+  } else if ((GetDataType() == QNN_DATATYPE_SFIXED_POINT_16 &&
+              rhs.GetDataType() == QNN_DATATYPE_UFIXED_POINT_16) ||
+             (GetDataType() == QNN_DATATYPE_UFIXED_POINT_16 &&
+              rhs.GetDataType() == QNN_DATATYPE_SFIXED_POINT_16)) {
+    constexpr int kSUFixed16OffsetDiff = 32768;
+    if (std::fabs(lhs_scale - rhs_scale) <
+            std::numeric_limits<float>::epsilon() &&
+        std::abs(lhs_offset - rhs_offset) == kSUFixed16OffsetDiff) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
@@ -1,0 +1,118 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_WRAPPERS_TENSOR_WRAPPER_H_
+#define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_WRAPPERS_TENSOR_WRAPPER_H_
+
+#include <string>
+#include <vector>
+
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h"
+#include "third_party/qairt/latest/include/QNN/QnnTypes.h"
+
+namespace qnn {
+
+std::size_t GetDataTypeSize(const Qnn_DataType_t data_type);
+
+class TensorWrapper final {
+  friend class TensorPool;
+
+ public:
+  explicit TensorWrapper();
+
+  explicit TensorWrapper(std::uint32_t id, Qnn_TensorType_t tensor_type,
+                         Qnn_DataType_t data_type,
+                         const QuantizeParamsWrapperVariant& quantize_params,
+                         const std::vector<std::uint32_t>& dimentions);
+
+  explicit TensorWrapper(std::uint32_t id, Qnn_TensorType_t tensor_type,
+                         Qnn_DataType_t data_type,
+                         const QuantizeParamsWrapperVariant& quantize_params,
+                         const std::vector<std::uint32_t>& dimentions,
+                         std::uint32_t bytes, const void* data);
+
+  TensorWrapper(const TensorWrapper& other);
+
+  TensorWrapper(TensorWrapper&& other);
+
+  ~TensorWrapper();
+
+  void CloneTo(Qnn_Tensor_t& dst) const;
+
+  Qnn_Tensor_t& GetQnnTensor() { return qnn_tensor_; }
+
+  std::uint32_t GetRank() const;
+
+  std::uint32_t GetDim(size_t index) const;
+
+  const std::vector<std::uint32_t>& GetDims() const { return dimentions_; };
+
+  const QuantizeParamsWrapperVariant& GetQuantParams() const {
+    return quantize_params_;
+  };
+
+  bool IsPerTensorQuantWithOffsetDiff(const TensorWrapper& rhs) const;
+
+  bool IsQuant8() const {
+    return GetDataType() == QNN_DATATYPE_SFIXED_POINT_8 ||
+           GetDataType() == QNN_DATATYPE_UFIXED_POINT_8;
+  }
+
+  bool IsQuant16() const {
+    return GetDataType() == QNN_DATATYPE_SFIXED_POINT_16 ||
+           GetDataType() == QNN_DATATYPE_UFIXED_POINT_16;
+  }
+
+  Qnn_DataType_t GetDataType() const;
+
+  void SetDataType(Qnn_DataType_t data_type);
+
+  bool IsSubgraphInput() const {
+    return GetTensorType() == QNN_TENSOR_TYPE_APP_WRITE;
+  }
+
+  bool IsSubgraphOutput() const {
+    return GetTensorType() == QNN_TENSOR_TYPE_APP_READ;
+  }
+
+  bool IsTensorStatic() const {
+    return GetTensorType() == QNN_TENSOR_TYPE_STATIC;
+  }
+
+  void SetTensorData(std::uint32_t bytes, const void* data);
+
+  const std::vector<std::byte>& GetTensorData() const { return owned_data_; }
+
+  // Allocate memory on owned_data_ for output tensors
+  void AllocateOutputTensorBuffer() {
+    owned_data_.resize(GetTensorSize());
+    qnn_tensor_.v2.clientBuf.dataSize = owned_data_.size();
+    qnn_tensor_.v2.clientBuf.data = owned_data_.data();
+  }
+
+  const void* GetStaticTensorData() const {
+    return qnn_tensor_.v2.clientBuf.data;
+  };
+
+ private:
+  size_t GetTensorSize() const;
+
+  Qnn_TensorType_t GetTensorType() const;
+
+  Qnn_Tensor_t qnn_tensor_{.version = QNN_TENSOR_VERSION_2,
+                           .v2 = QNN_TENSOR_V2_INIT};
+  std::string name_{};
+  std::vector<std::uint32_t> dimentions_{};
+  QuantizeParamsWrapperVariant quantize_params_{};
+  std::vector<std::byte> owned_data_{};
+};
+
+using TensorWrapperRef = std::reference_wrapper<TensorWrapper>;
+
+}  // namespace qnn
+
+#endif  // TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_WRAPPERS_TENSOR_WRAPPER_H_

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_WRAPPERS_TENSOR_WRAPPER_H_
 #define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_WRAPPERS_TENSOR_WRAPPER_H_
 


### PR DESCRIPTION
# WHAT
- Basic wrapper for QNN types, handle dynamic resources along with wrapper instances.
- Make these wrappers independent to LiteRT/tflite
- Only depend on QNN and STL 


### `ScalarParamWrapper`
- Wrap `Qnn_Param_t` with `QNN_PARAMTYPE_SCALAR` for `paramType` 
- Choose correct `QNN_DATATYPE` based on the data type

### `TensorParamWrapper`
- Wrap `Qnn_Param_t` with `QNN_PARAMTYPE_TENSOR` for `paramType`

### `UndefinedQuantizeParamsWrapper`
- Wrap `Qnn_QuantizeParams_t`
- Default for quantization parameter

### `ScaleOffsetQuantizeParamsWrapper`
- Wrap `Qnn_QuantizeParams_t` for per-tensor quantization 

### `AxisScaleOffsetQuantizeParamsWrapper`
- Wrap `Qnn_QuantizeParams_t`  for per-axis quantization

### `TensorWrapper`
- Wrap `Qnn_TensorType_t`
- Handle dynamic resource, e.g. name, dimensions, weight data.


### `OpWrapper`
- Wrap `Qnn_OpConfig_t`
- Handle dynamic resource, e.g. name, input output tensors, params