### PR TITLE
Support Op Builders in Core Module

### DIFF
--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/BUILD
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/BUILD
@@ -1,0 +1,22 @@
+# TODO: license
+
+package(
+    # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
+    default_visibility = ["//tensorflow/lite/experimental/litert/vendors/qualcomm:__subpackages__"],
+)
+
+cc_library(
+    name = "tensor_pool",
+    srcs = ["tensor_pool.cc"],
+    hdrs = ["tensor_pool.h"],
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "nobuilder",
+    ],
+    deps = [
+        # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
+        "//third_party/qairt/latest:qnn_lib_headers",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:quantize_params_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+    ],
+)

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/BUILD
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/BUILD
@@ -1,4 +1,5 @@
-# TODO: license
+#  Copyright (c) Qualcomm Innovation Center, Inc.
+#  All Rights Reserved.
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/BUILD
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/BUILD
@@ -15,7 +15,6 @@ cc_library(
     ],
     deps = [
         # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
-        "//third_party/qairt/latest:qnn_lib_headers",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:quantize_params_wrapper",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
     ],

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/BUILD
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/BUILD
@@ -15,7 +15,6 @@ cc_library(
     ],
     deps = [
         # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
-        "//third_party/qairt/latest:qnn_lib_headers",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
     ],
@@ -31,7 +30,6 @@ cc_library(
     ],
     deps = [
         # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
-        "//third_party/qairt/latest:qnn_lib_headers",
         ":op_builder",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:param_wrapper",
@@ -51,7 +49,6 @@ cc_library(
     ],
     deps = [
         # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
-        "//third_party/qairt/latest:qnn_lib_headers",
         ":op_builder",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
@@ -69,7 +66,6 @@ cc_library(
     ],
     deps = [
         # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
-        "//third_party/qairt/latest:qnn_lib_headers",
         ":op_builder",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
@@ -87,7 +83,6 @@ cc_library(
     ],
     deps = [
         # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
-        "//third_party/qairt/latest:qnn_lib_headers",
         ":op_builder",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
@@ -105,7 +100,6 @@ cc_library(
     ],
     deps = [
         # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
-        "//third_party/qairt/latest:qnn_lib_headers",
         ":op_builder",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
@@ -123,7 +117,6 @@ cc_library(
     ],
     deps = [
         # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
-        "//third_party/qairt/latest:qnn_lib_headers",
         ":op_builder",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
@@ -141,7 +134,6 @@ cc_library(
     ],
     deps = [
         # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
-        "//third_party/qairt/latest:qnn_lib_headers",
         ":op_builder",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
@@ -159,7 +151,6 @@ cc_library(
     ],
     deps = [
         # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
-        "//third_party/qairt/latest:qnn_lib_headers",
         ":op_builder",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
@@ -177,7 +168,6 @@ cc_library(
     ],
     deps = [
         # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
-        "//third_party/qairt/latest:qnn_lib_headers",
         ":op_builder",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
@@ -195,7 +185,6 @@ cc_library(
     ],
     deps = [
         # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
-        "//third_party/qairt/latest:qnn_lib_headers",
         ":op_builder",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
@@ -213,7 +202,6 @@ cc_library(
     ],
     deps = [
         # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
-        "//third_party/qairt/latest:qnn_lib_headers",
         ":op_builder",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
@@ -231,7 +219,6 @@ cc_library(
     ],
     deps = [
         # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
-        "//third_party/qairt/latest:qnn_lib_headers",
         ":op_builder",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
@@ -249,7 +236,6 @@ cc_library(
     ],
     deps = [
         # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
-        "//third_party/qairt/latest:qnn_lib_headers",
         ":op_builder",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
@@ -267,7 +253,6 @@ cc_library(
     ],
     deps = [
         # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
-        "//third_party/qairt/latest:qnn_lib_headers",
         ":op_builder",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
@@ -285,7 +270,6 @@ cc_library(
     ],
     deps = [
         # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
-        "//third_party/qairt/latest:qnn_lib_headers",
         ":op_builder",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
@@ -303,7 +287,6 @@ cc_library(
     ],
     deps = [
         # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
-        "//third_party/qairt/latest:qnn_lib_headers",
         ":op_builder",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
@@ -321,7 +304,6 @@ cc_library(
     ],
     deps = [
         # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
-        "//third_party/qairt/latest:qnn_lib_headers",
         ":op_builder",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
@@ -339,7 +321,6 @@ cc_library(
     ],
     deps = [
         # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
-        "//third_party/qairt/latest:qnn_lib_headers",
         ":op_builder",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/BUILD
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/BUILD
@@ -1,4 +1,5 @@
-# TODO: license
+#  Copyright (c) Qualcomm Innovation Center, Inc.
+#  All Rights Reserved.
 
 package(
     # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/BUILD
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/BUILD
@@ -1,0 +1,348 @@
+# TODO: license
+
+package(
+    # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
+    default_visibility = ["//tensorflow/lite/experimental/litert/vendors/qualcomm:__subpackages__"],
+)
+
+cc_library(
+    name = "op_builder",
+    srcs = ["op_builder.cc"],
+    hdrs = ["op_builder.h"],
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "nobuilder",
+    ],
+    deps = [
+        # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
+        "//third_party/qairt/latest:qnn_lib_headers",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+    ],
+)
+
+cc_library(
+    name = "elementwise_op_builder",
+    srcs = ["elementwise_op_builder.cc"],
+    hdrs = ["elementwise_op_builder.h"],
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "nobuilder",
+    ],
+    deps = [
+        # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
+        "//third_party/qairt/latest:qnn_lib_headers",
+        ":op_builder",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:param_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:quantize_params_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core:tensor_pool",
+    ],
+)
+
+cc_library(
+    name = "cast_op_builder",
+    srcs = ["cast_op_builder.cc"],
+    hdrs = ["cast_op_builder.h"],
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "nobuilder",
+    ],
+    deps = [
+        # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
+        "//third_party/qairt/latest:qnn_lib_headers",
+        ":op_builder",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core:tensor_pool",
+    ],
+)
+
+cc_library(
+    name = "concatenation_op_builder",
+    srcs = ["concatenation_op_builder.cc"],
+    hdrs = ["concatenation_op_builder.h"],
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "nobuilder",
+    ],
+    deps = [
+        # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
+        "//third_party/qairt/latest:qnn_lib_headers",
+        ":op_builder",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core:tensor_pool",
+    ],
+)
+
+cc_library(
+    name = "embedding_lookup_op_builder",
+    srcs = ["embedding_lookup_op_builder.cc"],
+    hdrs = ["embedding_lookup_op_builder.h"],
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "nobuilder",
+    ],
+    deps = [
+        # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
+        "//third_party/qairt/latest:qnn_lib_headers",
+        ":op_builder",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core:tensor_pool",
+    ],
+)
+
+cc_library(
+    name = "fully_connected_op_builder",
+    srcs = ["fully_connected_op_builder.cc"],
+    hdrs = ["fully_connected_op_builder.h"],
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "nobuilder",
+    ],
+    deps = [
+        # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
+        "//third_party/qairt/latest:qnn_lib_headers",
+        ":op_builder",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core:tensor_pool",
+    ],
+)
+
+cc_library(
+    name = "gather_op_builder",
+    srcs = ["gather_op_builder.cc"],
+    hdrs = ["gather_op_builder.h"],
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "nobuilder",
+    ],
+    deps = [
+        # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
+        "//third_party/qairt/latest:qnn_lib_headers",
+        ":op_builder",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core:tensor_pool",
+    ],
+)
+
+cc_library(
+    name = "gelu_op_builder",
+    srcs = ["gelu_op_builder.cc"],
+    hdrs = ["gelu_op_builder.h"],
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "nobuilder",
+    ],
+    deps = [
+        # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
+        "//third_party/qairt/latest:qnn_lib_headers",
+        ":op_builder",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core:tensor_pool",
+    ],
+)
+
+cc_library(
+    name = "matmul_op_builder",
+    srcs = ["matmul_op_builder.cc"],
+    hdrs = ["matmul_op_builder.h"],
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "nobuilder",
+    ],
+    deps = [
+        # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
+        "//third_party/qairt/latest:qnn_lib_headers",
+        ":op_builder",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core:tensor_pool",
+    ],
+)
+
+cc_library(
+    name = "mean_op_builder",
+    srcs = ["mean_op_builder.cc"],
+    hdrs = ["mean_op_builder.h"],
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "nobuilder",
+    ],
+    deps = [
+        # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
+        "//third_party/qairt/latest:qnn_lib_headers",
+        ":op_builder",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core:tensor_pool",
+    ],
+)
+
+cc_library(
+    name = "quantize_op_builder",
+    srcs = ["quantize_op_builder.cc"],
+    hdrs = ["quantize_op_builder.h"],
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "nobuilder",
+    ],
+    deps = [
+        # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
+        "//third_party/qairt/latest:qnn_lib_headers",
+        ":op_builder",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core:tensor_pool",
+    ],
+)
+
+cc_library(
+    name = "reduce_op_builder",
+    srcs = ["reduce_op_builder.cc"],
+    hdrs = ["reduce_op_builder.h"],
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "nobuilder",
+    ],
+    deps = [
+        # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
+        "//third_party/qairt/latest:qnn_lib_headers",
+        ":op_builder",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core:tensor_pool",
+    ],
+)
+
+cc_library(
+    name = "reshape_op_builder",
+    srcs = ["reshape_op_builder.cc"],
+    hdrs = ["reshape_op_builder.h"],
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "nobuilder",
+    ],
+    deps = [
+        # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
+        "//third_party/qairt/latest:qnn_lib_headers",
+        ":op_builder",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core:tensor_pool",
+    ],
+)
+
+cc_library(
+    name = "select_op_builder",
+    srcs = ["select_op_builder.cc"],
+    hdrs = ["select_op_builder.h"],
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "nobuilder",
+    ],
+    deps = [
+        # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
+        "//third_party/qairt/latest:qnn_lib_headers",
+        ":op_builder",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core:tensor_pool",
+    ],
+)
+
+cc_library(
+    name = "slice_op_builder",
+    srcs = ["slice_op_builder.cc"],
+    hdrs = ["slice_op_builder.h"],
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "nobuilder",
+    ],
+    deps = [
+        # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
+        "//third_party/qairt/latest:qnn_lib_headers",
+        ":op_builder",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core:tensor_pool",
+    ],
+)
+
+cc_library(
+    name = "softmax_op_builder",
+    srcs = ["softmax_op_builder.cc"],
+    hdrs = ["softmax_op_builder.h"],
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "nobuilder",
+    ],
+    deps = [
+        # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
+        "//third_party/qairt/latest:qnn_lib_headers",
+        ":op_builder",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core:tensor_pool",
+    ],
+)
+
+cc_library(
+    name = "split_op_builder",
+    srcs = ["split_op_builder.cc"],
+    hdrs = ["split_op_builder.h"],
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "nobuilder",
+    ],
+    deps = [
+        # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
+        "//third_party/qairt/latest:qnn_lib_headers",
+        ":op_builder",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core:tensor_pool",
+    ],
+)
+
+cc_library(
+    name = "tanh_op_builder",
+    srcs = ["tanh_op_builder.cc"],
+    hdrs = ["tanh_op_builder.h"],
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "nobuilder",
+    ],
+    deps = [
+        # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
+        "//third_party/qairt/latest:qnn_lib_headers",
+        ":op_builder",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core:tensor_pool",
+    ],
+)
+
+cc_library(
+    name = "transpose_op_builder",
+    srcs = ["transpose_op_builder.cc"],
+    hdrs = ["transpose_op_builder.h"],
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "nobuilder",
+    ],
+    deps = [
+        # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
+        "//third_party/qairt/latest:qnn_lib_headers",
+        ":op_builder",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core:tensor_pool",
+    ],
+)

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/cast_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/cast_op_builder.cc
@@ -1,0 +1,24 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/cast_op_builder.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildCastOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs) {
+  std::vector<OpWrapper> res;
+
+  auto& op = CreateOpWrapper(res, QNN_OP_CAST);
+  op.AddInputTensor(inputs[0]);
+  op.AddOutputTensor(outputs[0]);
+
+  return res;
+}
+
+}  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/cast_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/cast_op_builder.cc
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/cast_op_builder.h"
 
 namespace qnn {

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/cast_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/cast_op_builder.h
@@ -1,0 +1,24 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_CAST_OP_BUILDER_H_
+#define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_CAST_OP_BUILDER_H_
+
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/op_builder.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildCastOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs);
+
+}  // namespace qnn
+
+#endif  // TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_CAST_OP_BUILDER_H_

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/cast_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/cast_op_builder.h
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_CAST_OP_BUILDER_H_
 #define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_CAST_OP_BUILDER_H_
 

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/concatenation_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/concatenation_op_builder.cc
@@ -1,0 +1,31 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/concatenation_op_builder.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildConcatenationOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs, const std::int32_t axis) {
+  std::vector<OpWrapper> res;
+
+  auto& concat_op = CreateOpWrapper(res, QNN_OP_CONCAT);
+  for (const auto& input : inputs) {
+    concat_op.AddInputTensor(input);
+  }
+  concat_op.AddOutputTensor(outputs[0]);
+
+  std::uint32_t adjusted_axis =
+      (axis >= 0) ? axis : axis + inputs[0].get().GetRank();
+  concat_op.AddScalarParam<std::uint32_t>(QNN_OP_CONCAT_PARAM_AXIS,
+                                          adjusted_axis);
+
+  return res;
+}
+
+}  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/concatenation_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/concatenation_op_builder.cc
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/concatenation_op_builder.h"
 
 namespace qnn {

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/concatenation_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/concatenation_op_builder.h
@@ -1,0 +1,24 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_CONCATENATION_OP_BUILDER_H_
+#define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_CONCATENATION_OP_BUILDER_H_
+
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/op_builder.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildConcatenationOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs, const std::int32_t axis);
+
+}  // namespace qnn
+
+#endif  // TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_CONCATENATION_OP_BUILDER_H_

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/concatenation_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/concatenation_op_builder.h
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_CONCATENATION_OP_BUILDER_H_
 #define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_CONCATENATION_OP_BUILDER_H_
 

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/elementwise_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/elementwise_op_builder.cc
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/elementwise_op_builder.h"
 
 namespace qnn {

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/elementwise_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/elementwise_op_builder.cc
@@ -1,0 +1,194 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/elementwise_op_builder.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildElementwiseAddOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs) {
+  std::vector<OpWrapper> res;
+
+  auto& elementwise_op = CreateOpWrapper(res, QNN_OP_ELEMENT_WISE_ADD);
+  for (const auto& input : inputs) {
+    elementwise_op.AddInputTensor(input);
+  }
+  elementwise_op.AddOutputTensor(outputs[0]);
+
+  // TODO: fused activation
+  return res;
+}
+
+std::vector<OpWrapper> BuildElementwiseSubOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs) {
+  std::vector<OpWrapper> res;
+
+  auto& elementwise_op = CreateOpWrapper(res, QNN_OP_ELEMENT_WISE_SUBTRACT);
+  for (const auto& input : inputs) {
+    elementwise_op.AddInputTensor(input);
+  }
+  elementwise_op.AddOutputTensor(outputs[0]);
+
+  // TODO: fused activation
+  return res;
+}
+
+std::vector<OpWrapper> BuildElementwiseMulOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs) {
+  std::vector<OpWrapper> res;
+
+  auto& elementwise_op = CreateOpWrapper(res, QNN_OP_ELEMENT_WISE_MULTIPLY);
+  for (const auto& input : inputs) {
+    elementwise_op.AddInputTensor(input);
+  }
+  elementwise_op.AddOutputTensor(outputs[0]);
+
+  // TODO: fused activation
+  return res;
+}
+
+std::vector<OpWrapper> BuildElementwiseDivOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs) {
+  std::vector<OpWrapper> res;
+
+  auto& elementwise_op = CreateOpWrapper(res, QNN_OP_ELEMENT_WISE_DIVIDE);
+  for (const auto& input : inputs) {
+    elementwise_op.AddInputTensor(input);
+  }
+  elementwise_op.AddOutputTensor(outputs[0]);
+
+  // TODO: fused activation
+  return res;
+}
+
+std::vector<OpWrapper> BuildElementwiseSinOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs) {
+  std::vector<OpWrapper> res;
+
+  auto& elementwise_op = CreateOpWrapper(res, QNN_OP_ELEMENT_WISE_SIN);
+  for (const auto& input : inputs) {
+    elementwise_op.AddInputTensor(input);
+  }
+  elementwise_op.AddOutputTensor(outputs[0]);
+
+  return res;
+}
+
+std::vector<OpWrapper> BuildElementwiseCosOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs) {
+  std::vector<OpWrapper> res;
+
+  auto& elementwise_op = CreateOpWrapper(res, QNN_OP_ELEMENT_WISE_COS);
+  for (const auto& input : inputs) {
+    elementwise_op.AddInputTensor(input);
+  }
+  elementwise_op.AddOutputTensor(outputs[0]);
+
+  return res;
+}
+
+std::vector<OpWrapper> BuildElementwiseRsqrtOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs) {
+  std::vector<OpWrapper> res;
+
+  auto& elementwise_op = CreateOpWrapper(res, QNN_OP_ELEMENT_WISE_RSQRT);
+  for (const auto& input : inputs) {
+    elementwise_op.AddInputTensor(input);
+  }
+  elementwise_op.AddOutputTensor(outputs[0]);
+
+  return res;
+}
+
+std::vector<OpWrapper> BuildElementwiseSquareOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs) {
+  std::vector<OpWrapper> res;
+
+  OpWrapper& elementwise_op =
+      CreateOpWrapper(res, QNN_OP_ELEMENT_WISE_MULTIPLY);
+  elementwise_op.AddInputTensor(inputs[0]);
+  elementwise_op.AddInputTensor(inputs[0]);
+  elementwise_op.AddOutputTensor(outputs[0]);
+
+  return res;
+}
+
+std::vector<OpWrapper> BuildElementwiseSquaredDifferenceOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs) {
+  std::vector<OpWrapper> res;
+
+  auto& elementwise_op =
+      CreateOpWrapper(res, QNN_OP_ELEMENT_WISE_SQUARED_DIFFERENCE);
+  for (const auto& input : inputs) {
+    elementwise_op.AddInputTensor(input);
+  }
+  elementwise_op.AddOutputTensor(outputs[0]);
+
+  return res;
+}
+
+std::vector<OpWrapper> BuildElementwiseLessOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs) {
+  std::vector<OpWrapper> res;
+
+  auto& elementwise_op = CreateOpWrapper(res, QNN_OP_ELEMENT_WISE_BINARY);
+  for (const auto& input : inputs) {
+    elementwise_op.AddInputTensor(input);
+  }
+  elementwise_op.AddOutputTensor(outputs[0]);
+  elementwise_op.AddScalarParam<std::uint32_t>(
+      QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION,
+      QNN_OP_ELEMENT_WISE_BINARY_OPERATION_LESS);
+
+  return res;
+}
+
+std::vector<OpWrapper> BuildElementwiseGreaterOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs) {
+  std::vector<OpWrapper> res;
+
+  auto& elementwise_op = CreateOpWrapper(res, QNN_OP_ELEMENT_WISE_BINARY);
+  for (const auto& input : inputs) {
+    elementwise_op.AddInputTensor(input);
+  }
+  elementwise_op.AddOutputTensor(outputs[0]);
+  elementwise_op.AddScalarParam<std::uint32_t>(
+      QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION,
+      QNN_OP_ELEMENT_WISE_BINARY_OPERATION_GREATER);
+
+  return res;
+}
+
+std::vector<OpWrapper> BuildElementwiseAndOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs) {
+  std::vector<OpWrapper> res;
+
+  auto& elementwise_op = CreateOpWrapper(res, QNN_OP_ELEMENT_WISE_BINARY);
+  for (const auto& input : inputs) {
+    elementwise_op.AddInputTensor(input);
+  }
+  elementwise_op.AddOutputTensor(outputs[0]);
+  elementwise_op.AddScalarParam<std::uint32_t>(
+      QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION,
+      QNN_OP_ELEMENT_WISE_BINARY_OPERATION_AND);
+
+  return res;
+}
+
+}  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/elementwise_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/elementwise_op_builder.h
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_ELEMENTWISE_OP_BUILDER_H_
 #define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_ELEMENTWISE_OP_BUILDER_H_
 

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/elementwise_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/elementwise_op_builder.h
@@ -1,0 +1,68 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_ELEMENTWISE_OP_BUILDER_H_
+#define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_ELEMENTWISE_OP_BUILDER_H_
+
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/op_builder.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildElementwiseAddOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs);
+
+std::vector<OpWrapper> BuildElementwiseSubOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs);
+
+std::vector<OpWrapper> BuildElementwiseMulOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs);
+
+std::vector<OpWrapper> BuildElementwiseDivOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs);
+
+std::vector<OpWrapper> BuildElementwiseSinOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs);
+
+std::vector<OpWrapper> BuildElementwiseCosOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs);
+
+std::vector<OpWrapper> BuildElementwiseRsqrtOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs);
+
+std::vector<OpWrapper> BuildElementwiseSquareOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs);
+
+std::vector<OpWrapper> BuildElementwiseSquaredDifferenceOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs);
+
+std::vector<OpWrapper> BuildElementwiseLessOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs);
+
+std::vector<OpWrapper> BuildElementwiseGreaterOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs);
+
+std::vector<OpWrapper> BuildElementwiseAndOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs);
+
+}  // namespace qnn
+
+#endif  // TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_ELEMENTWISE_OP_BUILDER_H_

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/embedding_lookup_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/embedding_lookup_op_builder.cc
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/embedding_lookup_op_builder.h"
 
 namespace qnn {

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/embedding_lookup_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/embedding_lookup_op_builder.cc
@@ -1,0 +1,27 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/embedding_lookup_op_builder.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildEmbeddingLookupOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs) {
+  std::vector<OpWrapper> res;
+
+  auto& gather_op = CreateOpWrapper(res, QNN_OP_GATHER);
+  gather_op.AddInputTensor(inputs[1]);
+  gather_op.AddInputTensor(inputs[0]);
+  for (const auto& output : outputs) {
+    gather_op.AddOutputTensor(output);
+  }
+  gather_op.AddScalarParam<std::int32_t>(QNN_OP_GATHER_PARAM_AXIS, 0);
+  return res;
+}
+
+}  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/embedding_lookup_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/embedding_lookup_op_builder.h
@@ -1,0 +1,24 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_EMBEDDING_LOOKUP_OP_BUILDER_H_
+#define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_EMBEDDING_LOOKUP_OP_BUILDER_H_
+
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/op_builder.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildEmbeddingLookupOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs);
+
+}  // namespace qnn
+
+#endif  // TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_EMBEDDING_LOOKUP_OP_BUILDER_H_

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/embedding_lookup_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/embedding_lookup_op_builder.h
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_EMBEDDING_LOOKUP_OP_BUILDER_H_
 #define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_EMBEDDING_LOOKUP_OP_BUILDER_H_
 

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/fully_connected_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/fully_connected_op_builder.cc
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/fully_connected_op_builder.h"
 
 namespace qnn {

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/fully_connected_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/fully_connected_op_builder.cc
@@ -1,0 +1,61 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/fully_connected_op_builder.h"
+
+namespace qnn {
+
+namespace {
+constexpr int kBiasIdx = 2;
+}
+
+std::vector<OpWrapper> BuildFullyConnectedOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs, const bool keep_num_dims) {
+  std::vector<OpWrapper> res;
+
+  OpWrapper& fully_connected_op = CreateOpWrapper(res, QNN_OP_FULLY_CONNECTED);
+
+  TensorWrapper& input_tensor = inputs[0];
+  fully_connected_op.AddInputTensor(input_tensor);
+  TensorWrapper& weight_tensor = inputs[1];
+  fully_connected_op.AddInputTensor(weight_tensor);
+  if (inputs.size() - 1 >= kBiasIdx) {
+    TensorWrapper& bias_tensor = inputs[kBiasIdx];
+    fully_connected_op.AddInputTensor(bias_tensor);
+  }
+
+  TensorWrapper& output_tensor = outputs[0];
+  if (keep_num_dims) {
+    auto& input_dims = input_tensor.GetDims();
+    std::uint32_t input_size = std::accumulate(
+        input_dims.begin(), input_dims.end(), 1, std::multiplies<>());
+    const std::uint32_t num_units = weight_tensor.GetDim(0);
+    const std::uint32_t num_input_elem = weight_tensor.GetDim(1);
+
+    // input_size must be divisible by num_input_elem. This should be validated
+    // by QNN.
+    const std::uint32_t batch_size = input_size / num_input_elem;
+    // QNN output should always be rank 2
+    qnn::TensorWrapper& fully_connected_out = tensor_pool.CloneNativeTensorFrom(
+        output_tensor, {batch_size, num_units});
+
+    fully_connected_op.AddOutputTensor(fully_connected_out);
+    // TODO: fused activation
+
+    qnn::OpWrapper& reshape_op = CreateOpWrapper(res, QNN_OP_RESHAPE);
+    reshape_op.AddInputTensor(fully_connected_out);
+    reshape_op.AddOutputTensor(output_tensor);
+  } else {
+    fully_connected_op.AddOutputTensor(outputs[0]);
+    // TODO: fused activation
+  }
+
+  return res;
+}
+
+}  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/fully_connected_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/fully_connected_op_builder.h
@@ -1,0 +1,26 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_FULLY_CONNECTED_OP_BUILDER_H_
+#define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_FULLY_CONNECTED_OP_BUILDER_H_
+
+#include <numeric>
+
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/op_builder.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildFullyConnectedOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs, const bool keep_num_dims);
+
+}  // namespace qnn
+
+#endif  // TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_FULLY_CONNECTED_OP_BUILDER_H_

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/fully_connected_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/fully_connected_op_builder.h
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_FULLY_CONNECTED_OP_BUILDER_H_
 #define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_FULLY_CONNECTED_OP_BUILDER_H_
 

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/gather_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/gather_op_builder.cc
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/gather_op_builder.h"
 
 namespace qnn {

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/gather_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/gather_op_builder.cc
@@ -1,0 +1,38 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/gather_op_builder.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildGatherOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs, const std::int32_t axis,
+    const std::int32_t batch_dims) {
+  std::vector<OpWrapper> res;
+
+  if (batch_dims != 0) {
+    // TODO: error log
+    return res;
+  }
+
+  auto& gather_op = CreateOpWrapper(res, QNN_OP_GATHER);
+  for (const auto& input : inputs) {
+    gather_op.AddInputTensor(input);
+  }
+  for (const auto& output : outputs) {
+    gather_op.AddOutputTensor(output);
+  }
+  const std::int32_t adjusted_axis =
+      axis >= 0 ? axis : axis + inputs[0].get().GetRank();
+  gather_op.AddScalarParam<std::int32_t>(QNN_OP_GATHER_PARAM_AXIS,
+                                         adjusted_axis);
+
+  return res;
+}
+
+}  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/gather_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/gather_op_builder.h
@@ -1,0 +1,25 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_GATHER_OP_BUILDER_H_
+#define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_GATHER_OP_BUILDER_H_
+
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/op_builder.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildGatherOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs, const std::int32_t axis,
+    const std::int32_t batch_dims);
+
+}  // namespace qnn
+
+#endif  // TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_GATHER_OP_BUILDER_H_

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/gather_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/gather_op_builder.h
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_GATHER_OP_BUILDER_H_
 #define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_GATHER_OP_BUILDER_H_
 

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/gelu_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/gelu_op_builder.cc
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/gelu_op_builder.h"
 
 namespace qnn {

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/gelu_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/gelu_op_builder.cc
@@ -1,0 +1,23 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/gelu_op_builder.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildGeluOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs) {
+  std::vector<OpWrapper> res;
+
+  auto& gelu_op =
+      CreateSimpleActivationOp(res, QNN_OP_GELU, inputs[0], outputs[0]);
+
+  return res;
+}
+
+}  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/gelu_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/gelu_op_builder.h
@@ -1,0 +1,24 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_GELU_OP_BUILDER_H_
+#define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_GELU_OP_BUILDER_H_
+
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/op_builder.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildGeluOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs);
+
+}  // namespace qnn
+
+#endif  // TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_GELU_OP_BUILDER_H_

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/gelu_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/gelu_op_builder.h
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_GELU_OP_BUILDER_H_
 #define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_GELU_OP_BUILDER_H_
 

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/matmul_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/matmul_op_builder.cc
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/matmul_op_builder.h"
 
 namespace qnn {

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/matmul_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/matmul_op_builder.cc
@@ -1,0 +1,29 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/matmul_op_builder.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildMatmulOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs, const bool adj_x,
+    const bool adj_y) {
+  std::vector<OpWrapper> res;
+
+  auto& matmul_op = CreateOpWrapper(res, QNN_OP_MAT_MUL);
+  for (const auto& input : inputs) {
+    matmul_op.AddInputTensor(input);
+  }
+  matmul_op.AddOutputTensor(outputs[0]);
+  matmul_op.AddScalarParam<bool>(QNN_OP_MAT_MUL_PARAM_TRANSPOSE_IN0, adj_x);
+  matmul_op.AddScalarParam<bool>(QNN_OP_MAT_MUL_PARAM_TRANSPOSE_IN1, adj_y);
+
+  return res;
+}
+
+}  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/matmul_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/matmul_op_builder.h
@@ -1,0 +1,25 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_MATMUL_OP_BUILDER_H_
+#define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_MATMUL_OP_BUILDER_H_
+
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/op_builder.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildMatmulOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs, const bool adj_x,
+    const bool adj_y);
+
+}  // namespace qnn
+
+#endif  // TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_MATMUL_OP_BUILDER_H_

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/matmul_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/matmul_op_builder.h
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_MATMUL_OP_BUILDER_H_
 #define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_MATMUL_OP_BUILDER_H_
 

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/mean_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/mean_op_builder.cc
@@ -1,0 +1,54 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/mean_op_builder.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildMeanOp(TensorPool& tensor_pool,
+                                   const std::vector<TensorWrapperRef>& inputs,
+                                   const std::vector<TensorWrapperRef>& outputs,
+                                   const bool keep_dim) {
+  std::vector<OpWrapper> res;
+
+  TensorWrapper& axis_tensor = inputs[1];
+  if (!axis_tensor.IsTensorStatic() || axis_tensor.GetRank() != 1) {
+    // TODO: error log
+    return res;
+  }
+
+  TensorWrapper& input_tensor = inputs[0];
+
+  // TODO: cannot direcly cast
+  auto* axis_data =
+      reinterpret_cast<const std::int32_t*>(axis_tensor.GetStaticTensorData());
+  std::vector<std::uint32_t> adjusted_axis_data;
+  for (size_t i = 0; i < axis_tensor.GetDim(0); ++i) {
+    std::uint32_t adjusted_axis = axis_data[i] >= 0
+                                      ? axis_data[i]
+                                      : axis_data[i] + input_tensor.GetRank();
+    if (std::find(adjusted_axis_data.begin(), adjusted_axis_data.end(),
+                  adjusted_axis) == adjusted_axis_data.end()) {
+      adjusted_axis_data.emplace_back(adjusted_axis);
+    }
+  }
+  TensorWrapper& adjusted_axis_tensor = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_UINT_32, axis_tensor.GetQuantParams(),
+      {static_cast<const std::uint32_t>(adjusted_axis_data.size())},
+      sizeof(std::uint32_t) * adjusted_axis_data.size(),
+      adjusted_axis_data.data());
+
+  auto& reduce_op = CreateOpWrapper(res, QNN_OP_REDUCE_MEAN);
+  reduce_op.AddInputTensor(input_tensor);
+  reduce_op.AddOutputTensor(outputs[0]);
+  reduce_op.AddTensorParam(QNN_OP_REDUCE_MEAN_PARAM_AXES, adjusted_axis_tensor);
+  reduce_op.AddScalarParam<bool>(QNN_OP_REDUCE_MEAN_PARAM_KEEP_DIMS, keep_dim);
+
+  return res;
+}
+
+}  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/mean_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/mean_op_builder.cc
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/mean_op_builder.h"
 
 namespace qnn {

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/mean_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/mean_op_builder.h
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_MEAN_OP_BUILDER_H_
 #define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_MEAN_OP_BUILDER_H_
 

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/mean_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/mean_op_builder.h
@@ -1,0 +1,25 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_MEAN_OP_BUILDER_H_
+#define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_MEAN_OP_BUILDER_H_
+
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/op_builder.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildMeanOp(TensorPool& tensor_pool,
+                                   const std::vector<TensorWrapperRef>& inputs,
+                                   const std::vector<TensorWrapperRef>& outputs,
+                                   const bool keep_dims);
+
+}  // namespace qnn
+
+#endif  // TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_MEAN_OP_BUILDER_H_

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/op_builder.cc
@@ -1,0 +1,70 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/op_builder.h"
+
+namespace qnn {
+
+OpWrapper& CreateOpWrapper(std::vector<OpWrapper>& ops, const char* op_type) {
+  const auto op_count = ops.size();
+  const auto name = "op_type_" + std::string(op_type) + "_op_count_" +
+                    std::to_string(op_count);
+  return ops.emplace_back(std::move(name), op_type);
+}
+
+OpWrapper& CreateSimpleActivationOp(std::vector<OpWrapper>& ops,
+                                    const char* op_type,
+                                    const TensorWrapper& input_tensor,
+                                    const TensorWrapper& output_tensor) {
+  auto& ret = CreateOpWrapper(ops, op_type);
+  ret.AddInputTensor(input_tensor);
+  ret.AddOutputTensor(output_tensor);
+  return ret;
+}
+
+/*
+LiteRtStatus OpMapper::AddFusedActivationNode(
+    const tflite::ActivationFunctionType activation,
+    const TensorWrapper& input_tensor, const TensorWrapper& output_tensor) {
+  switch (activation) {
+    case tflite::ActivationFunctionType_RELU: {
+      OpWrapper& activation_op =
+          CreateSimpleActivationOp(QNN_OP_RELU, input_tensor, output_tensor);
+      break;
+    }
+    case tflite::ActivationFunctionType_RELU_N1_TO_1: {
+      OpWrapper& activation_op = CreateSimpleActivationOp(
+          QNN_OP_RELU_MIN_MAX, input_tensor, output_tensor);
+      activation_op.AddScalarParam<float>(QNN_OP_RELU_MIN_MAX_PARAM_MIN_VALUE,
+                                          -1.f);
+      activation_op.AddScalarParam<float>(QNN_OP_RELU_MIN_MAX_PARAM_MAX_VALUE,
+                                          1.f);
+      break;
+    }
+    case tflite::ActivationFunctionType_RELU6: {
+      OpWrapper& activation_op = CreateSimpleActivationOp(
+          QNN_OP_RELU_MIN_MAX, input_tensor, output_tensor);
+      activation_op.AddScalarParam<float>(QNN_OP_RELU_MIN_MAX_PARAM_MIN_VALUE,
+                                          0.f);
+      activation_op.AddScalarParam<float>(QNN_OP_RELU_MIN_MAX_PARAM_MAX_VALUE,
+                                          6.f);
+      break;
+    }
+    case tflite::ActivationFunctionType_TANH: {
+      OpWrapper& activation_op =
+          CreateSimpleActivationOp(QNN_OP_TANH, input_tensor, output_tensor);
+      break;
+    }
+    default:
+      return kLiteRtStatusErrorUnsupported;
+  }
+
+  return kLiteRtStatusOk;
+}
+*/
+
+}  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/op_builder.cc
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/op_builder.h"
 
 namespace qnn {

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/op_builder.h
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_OP_BUILDER_H_
 #define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_OP_BUILDER_H_
 

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/op_builder.h
@@ -1,0 +1,27 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_OP_BUILDER_H_
+#define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_OP_BUILDER_H_
+
+#include <vector>
+
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+
+OpWrapper& CreateOpWrapper(std::vector<OpWrapper>& ops, const char* op_type);
+
+OpWrapper& CreateSimpleActivationOp(std::vector<OpWrapper>& ops,
+                                    const char* op_type,
+                                    const TensorWrapper& input_tensor,
+                                    const TensorWrapper& output_tensor);
+
+}  // namespace qnn
+
+#endif  // TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_OP_BUILDER_H_

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/quantize_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/quantize_op_builder.cc
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/quantize_op_builder.h"
 
 namespace qnn {

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/quantize_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/quantize_op_builder.cc
@@ -1,0 +1,34 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/quantize_op_builder.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildQuantizeOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs) {
+  std::vector<OpWrapper> res;
+
+  const char* qnn_op = nullptr;
+  if (inputs[0].get().IsPerTensorQuantWithOffsetDiff(outputs[0].get())) {
+    qnn_op = QNN_OP_CAST;
+  } else if ((inputs[0].get().IsQuant8() || inputs[0].get().IsQuant16()) &&
+             (outputs[0].get().IsQuant8() || outputs[0].get().IsQuant16())) {
+    qnn_op = QNN_OP_CONVERT;
+  } else {
+    qnn_op = QNN_OP_QUANTIZE;
+  }
+
+  auto& quantize_op = CreateOpWrapper(res, qnn_op);
+  quantize_op.AddInputTensor(inputs[0]);
+  quantize_op.AddOutputTensor(outputs[0]);
+
+  return res;
+}
+
+}  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/quantize_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/quantize_op_builder.h
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_QUANTIZE_OP_BUILDER_H_
 #define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_QUANTIZE_OP_BUILDER_H_
 

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/quantize_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/quantize_op_builder.h
@@ -1,0 +1,24 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_QUANTIZE_OP_BUILDER_H_
+#define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_QUANTIZE_OP_BUILDER_H_
+
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/op_builder.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildQuantizeOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs);
+
+}  // namespace qnn
+
+#endif  // TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_QUANTIZE_OP_BUILDER_H_

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/reduce_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/reduce_op_builder.cc
@@ -1,18 +1,13 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/reduce_op_builder.h"
 
 namespace qnn {
 
-std::vector<OpWrapper> BuildReduceSumOp(TensorPool& tensor_pool,
-                                        const std::vector<TensorWrapperRef>& inputs,
-                                        const std::vector<TensorWrapperRef>& outputs,
-                                        const bool keep_dims) {
+std::vector<OpWrapper> BuildReduceSumOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs, const bool keep_dims) {
   std::vector<OpWrapper> res;
 
   TensorWrapper& axis_tensor = inputs[1];

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/reduce_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/reduce_op_builder.cc
@@ -1,0 +1,54 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/reduce_op_builder.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildReduceSumOp(TensorPool& tensor_pool,
+                                        const std::vector<TensorWrapperRef>& inputs,
+                                        const std::vector<TensorWrapperRef>& outputs,
+                                        const bool keep_dims) {
+  std::vector<OpWrapper> res;
+
+  TensorWrapper& axis_tensor = inputs[1];
+  if (!axis_tensor.IsTensorStatic() || axis_tensor.GetRank() != 1) {
+    // TODO: error log
+    return res;
+  }
+
+  TensorWrapper& input_tensor = inputs[0];
+
+  // TODO: cannot direcly cast
+  auto* axis_data =
+      reinterpret_cast<const std::int32_t*>(axis_tensor.GetStaticTensorData());
+  std::vector<std::uint32_t> adjusted_axis_data;
+  for (size_t i = 0; i < axis_tensor.GetDim(0); ++i) {
+    std::uint32_t adjusted_axis = axis_data[i] >= 0
+                                      ? axis_data[i]
+                                      : axis_data[i] + input_tensor.GetRank();
+    if (std::find(adjusted_axis_data.begin(), adjusted_axis_data.end(),
+                  adjusted_axis) == adjusted_axis_data.end()) {
+      adjusted_axis_data.emplace_back(adjusted_axis);
+    }
+  }
+  TensorWrapper& adjusted_axis_tensor = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_UINT_32, axis_tensor.GetQuantParams(),
+      {static_cast<const std::uint32_t>(adjusted_axis_data.size())},
+      sizeof(std::uint32_t) * adjusted_axis_data.size(),
+      adjusted_axis_data.data());
+
+  OpWrapper& reduce_op = CreateOpWrapper(res, QNN_OP_REDUCE_SUM);
+  reduce_op.AddInputTensor(input_tensor);
+  reduce_op.AddOutputTensor(outputs[0]);
+  reduce_op.AddTensorParam(QNN_OP_REDUCE_SUM_PARAM_AXES, adjusted_axis_tensor);
+  reduce_op.AddScalarParam<bool>(QNN_OP_REDUCE_SUM_PARAM_KEEP_DIMS, keep_dims);
+
+  return res;
+}
+
+}  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/reduce_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/reduce_op_builder.h
@@ -1,0 +1,25 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_REDUCE_OP_BUILDER_H_
+#define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_REDUCE_OP_BUILDER_H_
+
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/op_builder.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildReduceSumOp(TensorPool& tensor_pool,
+                                        const std::vector<TensorWrapperRef>& inputs,
+                                        const std::vector<TensorWrapperRef>& outputs,
+                                        const bool keep_dims);
+
+}  // namespace qnn
+
+#endif  // TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_REDUCE_OP_BUILDER_H_

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/reduce_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/reduce_op_builder.h
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_REDUCE_OP_BUILDER_H_
 #define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_REDUCE_OP_BUILDER_H_
 
@@ -15,10 +11,9 @@
 
 namespace qnn {
 
-std::vector<OpWrapper> BuildReduceSumOp(TensorPool& tensor_pool,
-                                        const std::vector<TensorWrapperRef>& inputs,
-                                        const std::vector<TensorWrapperRef>& outputs,
-                                        const bool keep_dims);
+std::vector<OpWrapper> BuildReduceSumOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs, const bool keep_dims);
 
 }  // namespace qnn
 

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/reshape_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/reshape_op_builder.cc
@@ -1,0 +1,24 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/reshape_op_builder.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildReshapeOp(TensorPool& tensor_pool,
+                                      const std::vector<TensorWrapperRef>& inputs,
+                                      const std::vector<TensorWrapperRef>& outputs) {
+  std::vector<OpWrapper> res;
+
+  auto& reshape_op = CreateOpWrapper(res, QNN_OP_RESHAPE);
+  reshape_op.AddInputTensor(inputs[0]);
+  reshape_op.AddOutputTensor(outputs[0]);
+
+  return res;
+}
+
+}  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/reshape_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/reshape_op_builder.cc
@@ -1,17 +1,13 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/reshape_op_builder.h"
 
 namespace qnn {
 
-std::vector<OpWrapper> BuildReshapeOp(TensorPool& tensor_pool,
-                                      const std::vector<TensorWrapperRef>& inputs,
-                                      const std::vector<TensorWrapperRef>& outputs) {
+std::vector<OpWrapper> BuildReshapeOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs) {
   std::vector<OpWrapper> res;
 
   auto& reshape_op = CreateOpWrapper(res, QNN_OP_RESHAPE);

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/reshape_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/reshape_op_builder.h
@@ -1,0 +1,24 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_RESHAPE_OP_BUILDER_H_
+#define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_RESHAPE_OP_BUILDER_H_
+
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/op_builder.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildReshapeOp(TensorPool& tensor_pool,
+                                      const std::vector<TensorWrapperRef>& inputs,
+                                      const std::vector<TensorWrapperRef>& outputs);
+
+}  // namespace qnn
+
+#endif  // TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_RESHAPE_OP_BUILDER_H_

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/reshape_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/reshape_op_builder.h
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_RESHAPE_OP_BUILDER_H_
 #define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_RESHAPE_OP_BUILDER_H_
 
@@ -15,9 +11,9 @@
 
 namespace qnn {
 
-std::vector<OpWrapper> BuildReshapeOp(TensorPool& tensor_pool,
-                                      const std::vector<TensorWrapperRef>& inputs,
-                                      const std::vector<TensorWrapperRef>& outputs);
+std::vector<OpWrapper> BuildReshapeOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs);
 
 }  // namespace qnn
 

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/select_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/select_op_builder.cc
@@ -1,0 +1,26 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/select_op_builder.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildSelectOp(TensorPool& tensor_pool,
+                                     const std::vector<TensorWrapperRef>& inputs,
+                                     const std::vector<TensorWrapperRef>& outputs) {
+  std::vector<OpWrapper> res;
+
+  auto& select_op = CreateOpWrapper(res, QNN_OP_ELEMENT_WISE_SELECT);
+  for (const auto& input : inputs) {
+    select_op.AddInputTensor(input);
+  }
+  select_op.AddOutputTensor(outputs[0]);
+
+  return res;
+}
+
+}  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/select_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/select_op_builder.cc
@@ -1,17 +1,13 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/select_op_builder.h"
 
 namespace qnn {
 
-std::vector<OpWrapper> BuildSelectOp(TensorPool& tensor_pool,
-                                     const std::vector<TensorWrapperRef>& inputs,
-                                     const std::vector<TensorWrapperRef>& outputs) {
+std::vector<OpWrapper> BuildSelectOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs) {
   std::vector<OpWrapper> res;
 
   auto& select_op = CreateOpWrapper(res, QNN_OP_ELEMENT_WISE_SELECT);

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/select_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/select_op_builder.h
@@ -1,0 +1,24 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_SELECT_OP_BUILDER_H_
+#define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_SELECT_OP_BUILDER_H_
+
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/op_builder.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildSelectOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs);
+
+}  // namespace qnn
+
+#endif  // TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_SELECT_OP_BUILDER_H_

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/select_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/select_op_builder.h
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_SELECT_OP_BUILDER_H_
 #define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_SELECT_OP_BUILDER_H_
 

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/slice_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/slice_op_builder.cc
@@ -1,0 +1,60 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/slice_op_builder.h"
+
+namespace qnn {
+
+namespace {
+constexpr int kDefaultStrideValue = 1;
+constexpr int kSizeNegative = -1;
+constexpr int kRangeNumElements = 3;
+}  // namespace
+
+std::vector<OpWrapper> BuildSliceOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs) {
+  std::vector<OpWrapper> res;
+
+  TensorWrapper& input_tensor = inputs[0];
+  TensorWrapper& begin_tensor = inputs[1];
+  TensorWrapper& size_tensor = inputs[2];
+  if (!begin_tensor.IsTensorStatic() || !size_tensor.IsTensorStatic()) {
+    // TODO: error log
+    return res;
+  }
+
+  const auto input_rank = input_tensor.GetRank();
+  auto begin_data =
+      reinterpret_cast<const std::int32_t*>(begin_tensor.GetStaticTensorData());
+  auto size_data =
+      reinterpret_cast<const std::int32_t*>(size_tensor.GetStaticTensorData());
+  std::vector<std::int32_t> range_data;
+  range_data.reserve(input_rank * kRangeNumElements);
+  for (size_t i = 0; i < input_rank; ++i) {
+    range_data.emplace_back(begin_data[i]);
+    if (size_data[i] == kSizeNegative) {
+      range_data.emplace_back(input_tensor.GetDim(i));
+    } else {
+      range_data.emplace_back(begin_data[i] + size_data[i]);
+    }
+    range_data.emplace_back(kDefaultStrideValue);
+  }
+  TensorWrapper& range_tensor = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_INT_32, begin_tensor.GetQuantParams(),
+      {input_rank, kRangeNumElements}, sizeof(std::int32_t) * range_data.size(),
+      range_data.data());
+
+  auto& slice_op = CreateOpWrapper(res, QNN_OP_STRIDED_SLICE);
+  slice_op.AddTensorParam(QNN_OP_STRIDED_SLICE_PARAM_RANGES, range_tensor);
+  slice_op.AddInputTensor(input_tensor);
+  slice_op.AddOutputTensor(outputs[0]);
+
+  return res;
+}
+
+}  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/slice_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/slice_op_builder.cc
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/slice_op_builder.h"
 
 namespace qnn {

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/slice_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/slice_op_builder.h
@@ -1,0 +1,23 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_SLICE_OP_BUILDER_H_
+#define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_SLICE_OP_BUILDER_H_
+
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/op_builder.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildSliceOp(TensorPool& tensor_pool,
+                                    const std::vector<TensorWrapperRef>& inputs,
+                                    const std::vector<TensorWrapperRef>& outputs);
+}  // namespace qnn
+
+#endif  // TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_SLICE_OP_BUILDER_H_

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/slice_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/slice_op_builder.h
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_SLICE_OP_BUILDER_H_
 #define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_SLICE_OP_BUILDER_H_
 
@@ -15,9 +11,9 @@
 
 namespace qnn {
 
-std::vector<OpWrapper> BuildSliceOp(TensorPool& tensor_pool,
-                                    const std::vector<TensorWrapperRef>& inputs,
-                                    const std::vector<TensorWrapperRef>& outputs);
+std::vector<OpWrapper> BuildSliceOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs);
 }  // namespace qnn
 
 #endif  // TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_SLICE_OP_BUILDER_H_

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/softmax_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/softmax_op_builder.cc
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/softmax_op_builder.h"
 
 namespace qnn {

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/softmax_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/softmax_op_builder.cc
@@ -1,0 +1,25 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/softmax_op_builder.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildSoftmaxOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs, const float beta) {
+  std::vector<OpWrapper> res;
+
+  auto& softmax_op = CreateOpWrapper(res, QNN_OP_SOFTMAX);
+  softmax_op.AddInputTensor(inputs[0]);
+  softmax_op.AddOutputTensor(outputs[0]);
+  softmax_op.AddScalarParam<float>(QNN_OP_SOFTMAX_PARAM_BETA, beta);
+
+  return res;
+}
+
+}  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/softmax_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/softmax_op_builder.h
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_SOFTMAX_OP_BUILDER_H_
 #define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_SOFTMAX_OP_BUILDER_H_
 

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/softmax_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/softmax_op_builder.h
@@ -1,0 +1,23 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_SOFTMAX_OP_BUILDER_H_
+#define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_SOFTMAX_OP_BUILDER_H_
+
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/op_builder.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildSoftmaxOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs, const float beta);
+}  // namespace qnn
+
+#endif  // TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_SOFTMAX_OP_BUILDER_H_

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/split_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/split_op_builder.cc
@@ -1,0 +1,58 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/split_op_builder.h"
+
+namespace qnn {
+
+namespace {
+constexpr int kSplitIndexRank = 1;
+constexpr int kinputAxisIndex = 0;
+}  // namespace
+
+std::vector<OpWrapper> BuildSplitOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs,
+    const std::uint32_t num_splits) {
+  std::vector<OpWrapper> res;
+
+  const TensorWrapper& axis_tensor = inputs[0];
+  if (!axis_tensor.IsTensorStatic()) {
+    return res;
+  }
+
+  const TensorWrapper& input_tensor = inputs[1];
+  auto* axis_data =
+      reinterpret_cast<const std::int32_t*>(axis_tensor.GetStaticTensorData());
+  std::uint32_t axis =
+      axis_data[0] >= 0 ? axis_data[0] : axis_data[0] + input_tensor.GetRank();
+
+  const std::uint32_t slice_size = input_tensor.GetDim(axis) / num_splits;
+  // The split_indice will do N cuts, split the dimension into N+1 clips
+  // so 0 will not be included in the split_indice
+  // for example, when we split 12 into 4 clip, the split index will be {3,6,9}
+  std::vector<std::uint32_t> split_indice;
+  split_indice.reserve(num_splits);
+  for (int i = 1; i < num_splits; i++) {
+    split_indice.emplace_back(static_cast<std::uint32_t>(i * slice_size));
+  }
+  TensorWrapper& split_indice_tensor = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_UINT_32, axis_tensor.GetQuantParams(), {num_splits - 1},
+      sizeof(std::uint32_t) * split_indice.size(), split_indice.data());
+
+  auto& split_op = CreateOpWrapper(res, QNN_OP_SPLIT);
+  split_op.AddInputTensor(input_tensor);
+  for (const auto& output : outputs) {
+    split_op.AddOutputTensor(output);
+  }
+  split_op.AddScalarParam<std::uint32_t>(QNN_OP_SPLIT_PARAM_AXIS, axis);
+  split_op.AddTensorParam(QNN_OP_SPLIT_PARAM_SPLIT_INDEX, split_indice_tensor);
+
+  return res;
+}
+
+}  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/split_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/split_op_builder.cc
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/split_op_builder.h"
 
 namespace qnn {

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/split_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/split_op_builder.h
@@ -1,0 +1,25 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_SPLIT_OP_BUILDER_H_
+#define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_SPLIT_OP_BUILDER_H_
+
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/op_builder.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildSplitOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs,
+    const std::uint32_t num_splits);
+
+}  // namespace qnn
+
+#endif  // TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_SPLIT_OP_BUILDER_H_

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/split_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/split_op_builder.h
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_SPLIT_OP_BUILDER_H_
 #define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_SPLIT_OP_BUILDER_H_
 

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/tanh_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/tanh_op_builder.cc
@@ -1,0 +1,23 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/tanh_op_builder.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildTanhOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs) {
+  std::vector<OpWrapper> res;
+
+  auto& tanh_op =
+      CreateSimpleActivationOp(res, QNN_OP_TANH, inputs[0], outputs[0]);
+
+  return res;
+}
+
+}  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/tanh_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/tanh_op_builder.cc
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/tanh_op_builder.h"
 
 namespace qnn {

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/tanh_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/tanh_op_builder.h
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_TANH_OP_BUILDER_H_
 #define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_TANH_OP_BUILDER_H_
 

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/tanh_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/tanh_op_builder.h
@@ -1,0 +1,24 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_TANH_OP_BUILDER_H_
+#define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_TANH_OP_BUILDER_H_
+
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/op_builder.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildTanhOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs);
+
+}  // namespace qnn
+
+#endif  // TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_TANH_OP_BUILDER_H_

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/transpose_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/transpose_op_builder.cc
@@ -1,0 +1,33 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/transpose_op_builder.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildTransposeOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs) {
+  std::vector<OpWrapper> res;
+
+  TensorWrapper& perm_tensor = inputs[1];
+  if (!perm_tensor.IsTensorStatic()) {
+    // TODO: error log
+    return res;
+  }
+
+  auto& transpose_op = CreateOpWrapper(res, QNN_OP_TRANSPOSE);
+  transpose_op.AddInputTensor(inputs[0]);
+  transpose_op.AddOutputTensor(outputs[0]);
+  transpose_op.AddTensorParam(
+      QNN_OP_TRANSPOSE_PARAM_PERM,
+      tensor_pool.CloneStaticTensorFrom(perm_tensor, QNN_DATATYPE_UINT_32));
+
+  return res;
+}
+
+}  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/transpose_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/transpose_op_builder.cc
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/transpose_op_builder.h"
 
 namespace qnn {

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/transpose_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/transpose_op_builder.h
@@ -1,0 +1,24 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_TRANSPOSE_OP_BUILDER_H_
+#define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_TRANSPOSE_OP_BUILDER_H_
+
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/op_builder.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildTransposeOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs);
+
+}  // namespace qnn
+
+#endif  // TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_TRANSPOSE_OP_BUILDER_H_

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/transpose_op_builder.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/transpose_op_builder.h
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_TRANSPOSE_OP_BUILDER_H_
 #define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_TRANSPOSE_OP_BUILDER_H_
 

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.cc
@@ -1,0 +1,102 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.h"
+
+namespace qnn {
+
+TensorPool::TensorPool() = default;
+
+TensorPool::TensorPool(std::function<void(TensorWrapper&)> tensor_callback)
+    : tensor_callback_{tensor_callback}, tensor_wrappers_{} {}
+
+TensorWrapper& TensorPool::CreateInputTensor(
+    Qnn_DataType_t data_type, const QuantizeParamsWrapperVariant& quant_params,
+    const std::vector<std::uint32_t>& dimentions) {
+  const auto id = tensor_wrappers_.size();
+  auto& back = tensor_wrappers_.emplace_back(
+      id, QNN_TENSOR_TYPE_APP_WRITE, data_type, quant_params, dimentions);
+
+  if (tensor_callback_) {
+    tensor_callback_(back);
+  }
+
+  return back;
+}
+
+TensorWrapper& TensorPool::CreateOutpuTensor(
+    Qnn_DataType_t data_type, const QuantizeParamsWrapperVariant& quant_params,
+    const std::vector<std::uint32_t>& dimentions) {
+  const auto id = tensor_wrappers_.size();
+  auto& back = tensor_wrappers_.emplace_back(
+      id, QNN_TENSOR_TYPE_APP_READ, data_type, quant_params, dimentions);
+
+  if (tensor_callback_) {
+    tensor_callback_(back);
+  }
+
+  return back;
+}
+
+TensorWrapper& TensorPool::CreateNativeTensor(
+    Qnn_DataType_t data_type, const QuantizeParamsWrapperVariant& quant_params,
+    const std::vector<std::uint32_t>& dimentions) {
+  const auto id = tensor_wrappers_.size();
+  auto& back = tensor_wrappers_.emplace_back(
+      id, QNN_TENSOR_TYPE_NATIVE, data_type, quant_params, dimentions);
+
+  if (tensor_callback_) {
+    tensor_callback_(back);
+  }
+
+  return back;
+}
+
+TensorWrapper& TensorPool::CreateStaticTensor(
+    Qnn_DataType_t data_type, const QuantizeParamsWrapperVariant& quant_params,
+    const std::vector<std::uint32_t>& dimentions, std::uint32_t bytes,
+    const void* data) {
+  const auto id = tensor_wrappers_.size();
+  auto& back =
+      tensor_wrappers_.emplace_back(id, QNN_TENSOR_TYPE_STATIC, data_type,
+                                    quant_params, dimentions, bytes, data);
+
+  if (tensor_callback_) {
+    tensor_callback_(back);
+  }
+
+  return back;
+}
+
+TensorWrapper& TensorPool::CloneNativeTensorFrom(const TensorWrapper& src) {
+  const auto id = tensor_wrappers_.size();
+  auto& back = tensor_wrappers_.emplace_back(
+      id, QNN_TENSOR_TYPE_NATIVE, src.GetDataType(), src.quantize_params_,
+      src.dimentions_);
+
+  if (tensor_callback_) {
+    tensor_callback_(back);
+  }
+
+  return back;
+}
+
+TensorWrapper& TensorPool::CloneNativeTensorFrom(
+    const TensorWrapper& src, const std::vector<std::uint32_t>& dimentions) {
+  const auto id = tensor_wrappers_.size();
+  auto& back = tensor_wrappers_.emplace_back(id, QNN_TENSOR_TYPE_NATIVE,
+                                             src.GetDataType(),
+                                             src.quantize_params_, dimentions);
+
+  if (tensor_callback_) {
+    tensor_callback_(back);
+  }
+
+  return back;
+}
+
+}  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.cc
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.h"
 
 namespace qnn {

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.cc
@@ -99,4 +99,18 @@ TensorWrapper& TensorPool::CloneNativeTensorFrom(
   return back;
 }
 
+TensorWrapper& TensorPool::CloneStaticTensorFrom(const TensorWrapper& src,
+                                                 Qnn_DataType_t data_type) {
+  const auto id = tensor_wrappers_.size();
+  auto& back = tensor_wrappers_.emplace_back(
+      id, QNN_TENSOR_TYPE_STATIC, data_type, src.quantize_params_,
+      src.dimentions_, src.owned_data_.size(), src.owned_data_.data());
+
+  if (tensor_callback_) {
+    tensor_callback_(back);
+  }
+
+  return back;
+}
+
 }  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.h
@@ -1,10 +1,6 @@
-//==============================================================================
-//
-//  Copyright (c) Qualcomm Technologies, Inc.
+//  Copyright (c) Qualcomm Innovation Center, Inc.
 //  All Rights Reserved.
-//  Confidential and Proprietary - Qualcomm Technologies, Inc.
-//
-//==============================================================================
+
 #ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_TENSOR_POOL_H_
 #define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_TENSOR_POOL_H_
 

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.h
@@ -1,0 +1,58 @@
+//==============================================================================
+//
+//  Copyright (c) Qualcomm Technologies, Inc.
+//  All Rights Reserved.
+//  Confidential and Proprietary - Qualcomm Technologies, Inc.
+//
+//==============================================================================
+#ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_TENSOR_POOL_H_
+#define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_TENSOR_POOL_H_
+
+#include <functional>
+#include <list>
+
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+#include "third_party/qairt/latest/include/QNN/QnnTypes.h"
+
+namespace qnn {
+
+class TensorPool {
+ public:
+  TensorPool();
+
+  TensorPool(std::function<void(TensorWrapper&)> tensor_callback);
+
+  TensorWrapper& CreateInputTensor(
+      Qnn_DataType_t data_type,
+      const QuantizeParamsWrapperVariant& quant_params,
+      const std::vector<std::uint32_t>& dimentions);
+
+  TensorWrapper& CreateOutpuTensor(
+      Qnn_DataType_t data_type,
+      const QuantizeParamsWrapperVariant& quant_params,
+      const std::vector<std::uint32_t>& dimentions);
+
+  TensorWrapper& CreateNativeTensor(
+      Qnn_DataType_t data_type,
+      const QuantizeParamsWrapperVariant& quant_params,
+      const std::vector<std::uint32_t>& dimentions);
+
+  TensorWrapper& CreateStaticTensor(
+      Qnn_DataType_t data_type,
+      const QuantizeParamsWrapperVariant& quant_params,
+      const std::vector<std::uint32_t>& dimentions, std::uint32_t bytes,
+      const void* data);
+
+  TensorWrapper& CloneNativeTensorFrom(const TensorWrapper& src);
+
+  TensorWrapper& CloneNativeTensorFrom(
+      const TensorWrapper& src, const std::vector<std::uint32_t>& dimentions);
+
+ private:
+  std::function<void(TensorWrapper&)> tensor_callback_{};
+  std::list<TensorWrapper> tensor_wrappers_{};
+};
+
+}  // namespace qnn
+
+#endif  // TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_TENSOR_POOL_H_

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/tensor_pool.h
@@ -48,6 +48,9 @@ class TensorPool {
   TensorWrapper& CloneNativeTensorFrom(
       const TensorWrapper& src, const std::vector<std::uint32_t>& dimentions);
 
+  TensorWrapper& CloneStaticTensorFrom(const TensorWrapper& src,
+                                       Qnn_DataType_t data_type);
+
  private:
   std::function<void(TensorWrapper&)> tensor_callback_{};
   std::list<TensorWrapper> tensor_wrappers_{};

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.cc
@@ -136,10 +136,6 @@ size_t TensorWrapper::GetTensorSize() const {
                          GetDataTypeSize(GetDataType()), std::multiplies<>());
 }
 
-void TensorWrapper::SetDataType(Qnn_DataType_t data_type) {
-  qnn_tensor_.v2.dataType = data_type;
-}
-
 void TensorWrapper::SetTensorData(std::uint32_t bytes, const void* data) {
   if (!IsSubgraphInput() && !IsTensorStatic()) {
     // TODO: error log

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
@@ -65,8 +65,6 @@ class TensorWrapper final {
 
   Qnn_DataType_t GetDataType() const;
 
-  void SetDataType(Qnn_DataType_t data_type);
-
   bool IsSubgraphInput() const {
     return GetTensorType() == QNN_TENSOR_TYPE_APP_WRITE;
   }


### PR DESCRIPTION
# WHAT
- Support Op implementations based on the wrappers.
- Use `TensorPool` to manage the intermediate tensors, `TensorPool` can be abstract or change to allocator if need.
- All builders are functions which receive `TensorPool`, input output `TensorWrapper`, and the op-specific parameters.
- All builders are functions which return `std::vector<OpWrapper>`
- The interface of all builders is open to change based on the requirement.
- Make these builders independent to LiteRT/tflite, use c++ primitive types as parameters.
- Only dependent on QNN and `Wrappers`.


# Supported Op 
| Supported Op | 
| --- | 
| Add |
| And |
| Cast  |
| Concat  |
| Cos |
| Div |
| Sin |
| Greater |
| Less |
| Mul |
| Rsqrt |
| Square |
| SquareDifference |
| Sub |
| EmbeddingLookUp |
| FullyConnected |
| Gather |
| GeLu |
| BatchMatMul |
| Mean |
| Quantize |
| Sum |
| Reshape |
| Select |
| SelectV2 |
| Slice |
| Softmax |
| Split |
| Tanh |
| Transpose |
