### PR TITLE
Qualcomm AI Engine Direct - Wrapper tests & Refactor tensor wrapper & Fix rms norm

### DIFF
--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/mean_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/mean_op_builder.cc
@@ -23,14 +23,16 @@ std::vector<OpWrapper> BuildMeanOp(TensorPool& tensor_pool,
 
   TensorWrapper& input_tensor = inputs[0];
 
-  // TODO: cannot direcly cast
-  auto* axis_data =
-      reinterpret_cast<const std::int32_t*>(axis_tensor.GetStaticTensorData());
+  auto axis_data = axis_tensor.GetStaticTensorData<std::int32_t>();
+  if (!axis_data.has_value()) {
+    QNN_LOG_ERROR("Get axis_data failed.");
+    return res;
+  }
   std::vector<std::uint32_t> adjusted_axis_data;
   for (size_t i = 0; i < axis_tensor.GetDim(0); ++i) {
-    std::uint32_t adjusted_axis = axis_data[i] >= 0
-                                      ? axis_data[i]
-                                      : axis_data[i] + input_tensor.GetRank();
+    std::uint32_t adjusted_axis =
+        (*axis_data)[i] >= 0 ? (*axis_data)[i]
+                             : (*axis_data)[i] + input_tensor.GetRank();
     if (std::find(adjusted_axis_data.begin(), adjusted_axis_data.end(),
                   adjusted_axis) == adjusted_axis_data.end()) {
       adjusted_axis_data.emplace_back(adjusted_axis);

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/reduce_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/reduce_op_builder.cc
@@ -22,14 +22,16 @@ std::vector<OpWrapper> BuildReduceSumOp(
 
   TensorWrapper& input_tensor = inputs[0];
 
-  // TODO: cannot direcly cast
-  auto* axis_data =
-      reinterpret_cast<const std::int32_t*>(axis_tensor.GetStaticTensorData());
+  auto axis_data = axis_tensor.GetStaticTensorData<std::int32_t>();
+  if (!axis_data.has_value()) {
+    QNN_LOG_ERROR("Get axis_data failed.");
+    return res;
+  }
   std::vector<std::uint32_t> adjusted_axis_data;
   for (size_t i = 0; i < axis_tensor.GetDim(0); ++i) {
-    std::uint32_t adjusted_axis = axis_data[i] >= 0
-                                      ? axis_data[i]
-                                      : axis_data[i] + input_tensor.GetRank();
+    std::uint32_t adjusted_axis =
+        (*axis_data)[i] >= 0 ? (*axis_data)[i]
+                             : (*axis_data)[i] + input_tensor.GetRank();
     if (std::find(adjusted_axis_data.begin(), adjusted_axis_data.end(),
                   adjusted_axis) == adjusted_axis_data.end()) {
       adjusted_axis_data.emplace_back(adjusted_axis);

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/rms_norm_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/rms_norm_op_builder.cc
@@ -11,6 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/rms_norm_op_builder.h"
 
@@ -28,37 +31,48 @@
 namespace qnn {
 
 static constexpr int kInputIndex = 0;
-static constexpr int kAxisIndex = 1;
+static constexpr int kGammaIndex = 1;
 
 std::vector<OpWrapper> BuildRmsNormOp(
     TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
     const std::vector<TensorWrapperRef>& outputs, const float epsilon) {
   std::vector<OpWrapper> res;
+
   auto& rms_norm_op = CreateOpWrapper(res, QNN_OP_RMS_NORM);
+  for (const auto& input : inputs) {
+    rms_norm_op.AddInputTensor(input);
+  }
 
   // Constructs axis param tensor.
   std::vector<std::uint32_t> axis_data;
-  axis_data.reserve(inputs[kAxisIndex].get().GetRank());
   axis_data.emplace_back(inputs[kInputIndex].get().GetRank() - 1);
   TensorWrapper& axis_tensor = tensor_pool.CreateStaticTensor(
       QNN_DATATYPE_UINT_32, inputs[kInputIndex].get().GetQuantParams(), {1},
       sizeof(std::uint32_t) * axis_data.size(), axis_data.data());
 
-  // Construct beta static all 0 tensor.
-  std::vector<int8_t> beta_data;
-  beta_data.reserve(GetDataTypeSize(inputs[kAxisIndex].get().GetDataType()) *
-                    inputs[kAxisIndex].get().GetTensorSize());
-  std::memset(beta_data.data(), 0, beta_data.size());
-  TensorWrapper& beta_tensor = tensor_pool.CreateStaticTensor(
-      inputs[kAxisIndex].get().GetDataType(),
-      inputs[kAxisIndex].get().GetQuantParams(),
-      inputs[kAxisIndex].get().GetDims(), sizeof(int8_t) * beta_data.size(),
-      beta_data.data());
+  if (inputs[kGammaIndex].get().GetDataType() == QNN_DATATYPE_FLOAT_32) {
+    // Construct float beta static all 0 tensor.
+    std::vector<float> beta_data(
+        inputs[kGammaIndex].get().GetTensorNumElements(), 0);
+    TensorWrapper& beta_tensor = tensor_pool.CreateStaticTensor(
+        inputs[kGammaIndex].get().GetDataType(),
+        inputs[kGammaIndex].get().GetQuantParams(),
+        inputs[kGammaIndex].get().GetDims(), sizeof(float) * beta_data.size(),
+        beta_data.data());
+    rms_norm_op.AddInputTensor(beta_tensor);
+  } else {
+    // Construct uint8_t beta static all 0 tensor.
+    std::vector<uint8_t> beta_data(
+        inputs[kGammaIndex].get().GetTensorNumElements(), 0);
 
-  for (const auto& input : inputs) {
-    rms_norm_op.AddInputTensor(input);
+    // Offset needs to be 0, scale does not matter since data is 0
+    ScaleOffsetQuantizeParamsWrapper q_param(0.00001, 0);
+
+    TensorWrapper& beta_tensor = tensor_pool.CreateStaticTensor(
+        QNN_DATATYPE_UINT_8, q_param, inputs[kGammaIndex].get().GetDims(),
+        sizeof(uint8_t) * beta_data.size(), beta_data.data());
+    rms_norm_op.AddInputTensor(beta_tensor);
   }
-  rms_norm_op.AddInputTensor(beta_tensor);
 
   rms_norm_op.AddScalarParam<float>(QNN_OP_RMS_NORM_PARAM_EPSILON, epsilon);
   rms_norm_op.AddTensorParam(QNN_OP_RMS_NORM_PARAM_AXES, axis_tensor);

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/slice_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/slice_op_builder.cc
@@ -28,18 +28,24 @@ std::vector<OpWrapper> BuildSliceOp(
   }
 
   const auto input_rank = input_tensor.GetRank();
-  auto begin_data =
-      reinterpret_cast<const std::int32_t*>(begin_tensor.GetStaticTensorData());
-  auto size_data =
-      reinterpret_cast<const std::int32_t*>(size_tensor.GetStaticTensorData());
+  auto begin_data = begin_tensor.GetStaticTensorData<int32_t>();
+  if (!begin_data.has_value()) {
+    QNN_LOG_ERROR("Get begin_data failed.");
+    return res;
+  }
+  auto size_data = size_tensor.GetStaticTensorData<int32_t>();
+  if (!size_data.has_value()) {
+    QNN_LOG_ERROR("Get size_data failed.");
+    return res;
+  }
   std::vector<std::int32_t> range_data;
   range_data.reserve(input_rank * kRangeNumElements);
   for (size_t i = 0; i < input_rank; ++i) {
-    range_data.emplace_back(begin_data[i]);
-    if (size_data[i] == kSizeNegative) {
+    range_data.emplace_back((*begin_data)[i]);
+    if ((*size_data)[i] == kSizeNegative) {
       range_data.emplace_back(input_tensor.GetDim(i));
     } else {
-      range_data.emplace_back(begin_data[i] + size_data[i]);
+      range_data.emplace_back((*begin_data)[i] + (*size_data)[i]);
     }
     range_data.emplace_back(kDefaultStrideValue);
   }

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/split_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/split_op_builder.cc
@@ -22,10 +22,14 @@ std::vector<OpWrapper> BuildSplitOp(
   }
 
   const TensorWrapper& input_tensor = inputs[1];
-  auto* axis_data =
-      reinterpret_cast<const std::int32_t*>(axis_tensor.GetStaticTensorData());
-  std::uint32_t axis =
-      axis_data[0] >= 0 ? axis_data[0] : axis_data[0] + input_tensor.GetRank();
+  auto axis_data = axis_tensor.GetStaticTensorData<int32_t>();
+  if (!axis_data.has_value()) {
+    QNN_LOG_ERROR("Get axis_data failed.");
+    return res;
+  }
+  std::uint32_t axis = (*axis_data)[0] >= 0
+                           ? (*axis_data)[0]
+                           : (*axis_data)[0] + input_tensor.GetRank();
 
   const std::uint32_t slice_size = input_tensor.GetDim(axis) / num_splits;
   // The split_indice will do N cuts, split the dimension into N+1 clips

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/BUILD
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/BUILD
@@ -30,6 +30,7 @@ cc_library(
     ],
     deps = [
         ":quantize_params_wrapper",
+        "@com_google_absl//absl/types:span",
         # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
         "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/utils:log",
     ],

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.cc
@@ -5,7 +5,6 @@
 
 #include <cmath>
 #include <cstdint>
-#include <cstring>
 #include <functional>
 #include <iostream>
 #include <limits>
@@ -87,7 +86,7 @@ TensorWrapper::TensorWrapper(
     const std::vector<std::uint32_t>& dimentions, std::uint32_t bytes,
     const void* data)
     : TensorWrapper(id, tensor_type, data_type, quantize_params, dimentions) {
-  SetTensorData(bytes, data);
+  SetTensorDataViaVoidPtr(bytes, data);
 }
 
 TensorWrapper::TensorWrapper(const TensorWrapper& other)
@@ -140,34 +139,18 @@ Qnn_TensorType_t TensorWrapper::GetTensorType() const {
   return qnn_tensor_.v2.type;
 }
 
-size_t TensorWrapper::GetTensorSize() const {
-  return std::accumulate(GetDims().begin(), GetDims().end(),
-                         GetDataTypeSize(GetDataType()), std::multiplies<>());
+std::uint32_t TensorWrapper::GetTensorNumElements() const {
+  return GetDims().empty() ? 0
+                           : std::accumulate(GetDims().begin(), GetDims().end(),
+                                             1, std::multiplies<>());
+}
+
+size_t TensorWrapper::GetTensorBytes() const {
+  return GetDataTypeSize(GetDataType()) * GetTensorNumElements();
 }
 
 void TensorWrapper::SetDataType(Qnn_DataType_t data_type) {
   qnn_tensor_.v2.dataType = data_type;
-}
-
-void TensorWrapper::SetTensorData(std::uint32_t bytes, const void* data) {
-  if (!IsSubgraphInput() && !IsTensorStatic()) {
-    QNN_LOG_ERROR(
-        "Cannot set tensor data of tensor type other than "
-        "QNN_TENSOR_TYPE_APP_WRITE or QNN_TENSOR_TYPE_STATIC.");
-    return;
-  }
-
-  if (bytes != GetTensorSize()) {
-    QNN_LOG_WARNING("Bytes: %u != TensorSize(): %lu, use TensorSize() instead.",
-                    bytes, GetTensorSize());
-    bytes = GetTensorSize();
-  }
-
-  owned_data_.resize(bytes);
-  std::memcpy(owned_data_.data(), reinterpret_cast<const char*>(data), bytes);
-
-  qnn_tensor_.v2.clientBuf.dataSize = owned_data_.size();
-  qnn_tensor_.v2.clientBuf.data = owned_data_.data();
 }
 
 bool TensorWrapper::IsPerTensorQuantWithOffsetDiff(
@@ -213,6 +196,20 @@ bool TensorWrapper::IsPerTensorQuantWithOffsetDiff(
     }
   }
   return false;
+}
+
+void TensorWrapper::SetTensorDataViaVoidPtr(std::uint32_t bytes,
+                                            const void* data) {
+  if (bytes != GetTensorBytes()) {
+    QNN_LOG_WARNING(
+        "Bytes: %d != GetTensorBytes(): %d, use GetTensorBytes() instead.",
+        bytes, GetTensorBytes());
+    bytes = GetTensorBytes();
+  }
+  owned_data_.resize(bytes);
+  std::memcpy(owned_data_.data(), reinterpret_cast<const char*>(data), bytes);
+  qnn_tensor_.v2.clientBuf.dataSize = owned_data_.size();
+  qnn_tensor_.v2.clientBuf.data = owned_data_.data();
 }
 
 }  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
@@ -1,16 +1,45 @@
-// Copyright (c) Qualcomm Innovation Center, Inc.
-// All Rights Reserved.
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 #ifndef TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_WRAPPERS_TENSOR_WRAPPER_H_
 #define TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_WRAPPERS_TENSOR_WRAPPER_H_
 
+#include <cstring>
+#include <optional>
 #include <string>
 #include <vector>
 
-#include "third_party/qairt/latest/include/QNN/QnnTypes.h"
+#include "absl/types/span.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/utils/log.h"
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h"
+#include "third_party/qairt/latest/include/QNN/QnnTypes.h"
 
 namespace qnn {
+
+// Get the Qnn_DataType_t associated with given C++ type.
+template <typename T>
+inline constexpr Qnn_DataType_t GetQnnDataType(const bool is_quant) {
+  if constexpr (std::is_same_v<T, bool>) {
+    return QNN_DATATYPE_BOOL_8;
+  } else if constexpr (std::is_same_v<T, std::uint8_t>) {
+    return is_quant ? QNN_DATATYPE_UFIXED_POINT_8 : QNN_DATATYPE_UINT_8;
+  } else if constexpr (std::is_same_v<T, std::int8_t>) {
+    return is_quant ? QNN_DATATYPE_SFIXED_POINT_8 : QNN_DATATYPE_INT_8;
+  } else if constexpr (std::is_same_v<T, std::uint16_t>) {
+    return is_quant ? QNN_DATATYPE_UFIXED_POINT_16 : QNN_DATATYPE_UINT_16;
+  } else if constexpr (std::is_same_v<T, std::int16_t>) {
+    return is_quant ? QNN_DATATYPE_SFIXED_POINT_16 : QNN_DATATYPE_INT_16;
+  } else if constexpr (std::is_same_v<T, std::uint32_t>) {
+    return is_quant ? QNN_DATATYPE_UFIXED_POINT_32 : QNN_DATATYPE_UINT_32;
+  } else if constexpr (std::is_same_v<T, std::int32_t>) {
+    return is_quant ? QNN_DATATYPE_SFIXED_POINT_32 : QNN_DATATYPE_INT_32;
+  } else if constexpr (std::is_same_v<T, float>) {
+    return QNN_DATATYPE_FLOAT_32;
+  } else {
+    static_assert(false, "Uknown C++ type");
+  }
+  return QNN_DATATYPE_UNDEFINED;
+}
 
 std::size_t GetDataTypeSize(const Qnn_DataType_t data_type);
 
@@ -47,8 +76,15 @@ class TensorWrapper final {
 
   const std::vector<std::uint32_t>& GetDims() const { return dimentions_; };
 
+  std::uint32_t GetTensorNumElements() const;
+
   const QuantizeParamsWrapperVariant& GetQuantParams() const {
     return quantize_params_;
+  };
+
+  const bool IsQuant() const {
+    return !std::holds_alternative<UndefinedQuantizeParamsWrapper>(
+        quantize_params_);
   };
 
   bool IsPerTensorQuantWithOffsetDiff(const TensorWrapper& rhs) const;
@@ -79,25 +115,126 @@ class TensorWrapper final {
     return GetTensorType() == QNN_TENSOR_TYPE_STATIC;
   }
 
-  void SetTensorData(std::uint32_t bytes, const void* data);
+  template <typename T>
+  bool SetTensorData(absl::Span<const T> data) {
+    if (!IsSubgraphInput() && !IsTensorStatic()) {
+      QNN_LOG_ERROR(
+          "Cannot set tensor data of tensor type other than "
+          "QNN_TENSOR_TYPE_APP_WRITE or QNN_TENSOR_TYPE_STATIC.");
+      return false;
+    }
 
-  const std::vector<std::byte>& GetTensorData() const { return owned_data_; }
+    size_t num_elements = GetTensorNumElements();
+    if (!num_elements) {
+      QNN_LOG_ERROR("Cannot set tensor data, number of elements = 0");
+      return false;
+    }
+
+    size_t data_bytes = sizeof(T) * data.size();
+    size_t tensor_bytes = GetTensorBytes();
+    if (tensor_bytes > data_bytes) {
+      QNN_LOG_ERROR(
+          "Tensor bytes: %d > given data bytes: %d, SetTensorData failed.",
+          tensor_bytes, data_bytes);
+      return false;
+    }
+    if (tensor_bytes < data_bytes) {
+      QNN_LOG_WARNING(
+          "Tensor bytes : %d < given data bytes: %d, using only %d.",
+          tensor_bytes, data_bytes, tensor_bytes);
+    }
+
+    if constexpr (std::is_same_v<T, float>) {
+      if (qnn_tensor_.v2.dataType != QNN_DATATYPE_FLOAT_32) {
+        QNN_LOG_ERROR(
+            "Cannot set tensor data, setting float data on QNN data type %d.",
+            qnn_tensor_.v2.dataType);
+        return false;
+      }
+    } else if constexpr (std::is_same_v<T, std::int8_t>) {
+      if (qnn_tensor_.v2.dataType != QNN_DATATYPE_INT_8 &&
+          qnn_tensor_.v2.dataType != QNN_DATATYPE_SFIXED_POINT_8) {
+        QNN_LOG_ERROR(
+            "Cannot set tensor data, setting std::int8_t data on QNN data type "
+            "%d.",
+            qnn_tensor_.v2.dataType);
+        return false;
+      }
+    } else if constexpr (std::is_same_v<T, std::uint8_t>) {
+      if (qnn_tensor_.v2.dataType != QNN_DATATYPE_UINT_8 &&
+          qnn_tensor_.v2.dataType != QNN_DATATYPE_UFIXED_POINT_8) {
+        QNN_LOG_ERROR(
+            "Cannot set tensor data, setting std::uint8_t data on QNN data "
+            "type %d.",
+            qnn_tensor_.v2.dataType);
+        return false;
+      }
+    } else if constexpr (std::is_same_v<T, std::int16_t>) {
+      if (qnn_tensor_.v2.dataType != QNN_DATATYPE_INT_16 &&
+          qnn_tensor_.v2.dataType != QNN_DATATYPE_SFIXED_POINT_16) {
+        QNN_LOG_ERROR(
+            "Cannot set tensor data, setting std::int16_t data on QNN data "
+            "type %d.",
+            qnn_tensor_.v2.dataType);
+        return false;
+      }
+    } else if constexpr (std::is_same_v<T, std::uint16_t>) {
+      if (qnn_tensor_.v2.dataType != QNN_DATATYPE_UINT_16 &&
+          qnn_tensor_.v2.dataType != QNN_DATATYPE_UFIXED_POINT_16) {
+        QNN_LOG_ERROR(
+            "Cannot set tensor data, setting std::uint16_t data on QNN data "
+            "type %d.",
+            qnn_tensor_.v2.dataType);
+        return false;
+      }
+
+    } else if constexpr (std::is_same_v<T, std::int32_t>) {
+      if (qnn_tensor_.v2.dataType != QNN_DATATYPE_INT_32 &&
+          qnn_tensor_.v2.dataType != QNN_DATATYPE_SFIXED_POINT_32) {
+        QNN_LOG_ERROR(
+            "Cannot set tensor data, setting std::int32_t data on QNN data "
+            "type %d.",
+            qnn_tensor_.v2.dataType);
+        return false;
+      }
+    } else if constexpr (std::is_same_v<T, std::uint32_t>) {
+      if (qnn_tensor_.v2.dataType != QNN_DATATYPE_UINT_32 &&
+          qnn_tensor_.v2.dataType != QNN_DATATYPE_UFIXED_POINT_32) {
+        QNN_LOG_ERROR(
+            "Cannot set tensor data, setting std::uint32_t data on QNN data "
+            "type %d.",
+            qnn_tensor_.v2.dataType);
+        return false;
+      }
+    } else {
+      QNN_LOG_ERROR("Cannot set tensor data, unknown data type.");
+      return false;
+    }
+
+    owned_data_.resize(tensor_bytes);
+    std::memcpy(owned_data_.data(), reinterpret_cast<const char*>(data.data()),
+                tensor_bytes);
+    qnn_tensor_.v2.clientBuf.dataSize = owned_data_.size();
+    qnn_tensor_.v2.clientBuf.data = owned_data_.data();
+    return true;
+  }
 
   // Allocate memory on owned_data_ for output tensors
   void AllocateOutputTensorBuffer() {
-    owned_data_.resize(GetTensorSize());
+    owned_data_.resize(GetTensorBytes());
     qnn_tensor_.v2.clientBuf.dataSize = owned_data_.size();
     qnn_tensor_.v2.clientBuf.data = owned_data_.data();
   }
 
-  const void* GetStaticTensorData() const {
-    return qnn_tensor_.v2.clientBuf.data;
-  };
+  template <typename T>
+  std::optional<absl::Span<const T>> GetStaticTensorData() const;
 
-  size_t GetTensorSize() const;
+  size_t GetTensorBytes() const;
 
  private:
   Qnn_TensorType_t GetTensorType() const;
+
+  void SetTensorDataViaVoidPtr(std::uint32_t bytes, const void* data);
 
   Qnn_Tensor_t qnn_tensor_{.version = QNN_TENSOR_VERSION_2,
                            .v2 = QNN_TENSOR_V2_INIT};
@@ -109,6 +246,40 @@ class TensorWrapper final {
 
 using TensorWrapperRef = std::reference_wrapper<TensorWrapper>;
 
+template <typename T>
+std::optional<absl::Span<const T>> TensorWrapper::GetStaticTensorData() const {
+  if (!IsTensorStatic()) {
+    QNN_LOG_ERROR(
+        "Cannot GetStaticTensorData() on a non-static tensor, tensor type %d.",
+        GetTensorType());
+    return std::nullopt;
+  }
+
+  if (GetDataType() != GetQnnDataType<T>(IsQuant())) {
+    QNN_LOG_ERROR("GetStaticTensorData() with incorrect template type.");
+    return std::nullopt;
+  }
+
+  if (qnn_tensor_.v2.clientBuf.dataSize == 0 ||
+      qnn_tensor_.v2.clientBuf.data == nullptr) {
+    QNN_LOG_ERROR("Empty StaticTensorData.");
+    return std::nullopt;
+  }
+
+  if (qnn_tensor_.v2.clientBuf.dataSize != GetTensorBytes()) {
+    QNN_LOG_ERROR("Tensor bytes != stored data bytes.");
+    return std::nullopt;
+  }
+
+  uint32_t num_elements = qnn_tensor_.v2.clientBuf.dataSize / sizeof(T);
+  if (!num_elements) {
+    QNN_LOG_ERROR("No element in this tensor.");
+    return std::nullopt;
+  }
+
+  return absl::MakeConstSpan(
+      reinterpret_cast<const T*>(qnn_tensor_.v2.clientBuf.data), num_elements);
+}
 }  // namespace qnn
 
 #endif  // TENSORFLOW_LITE_EXPERIMENTAL_LITERT_VENDORS_QUALCOMM_CORE_WRAPPERS_TENSOR_WRAPPER_H_

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tests/BUILD
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tests/BUILD
@@ -1,0 +1,54 @@
+# Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+package(
+    # copybara:uncomment default_applicable_licenses = ["//tensorflow:license"],
+    default_visibility = ["//tensorflow/lite/experimental/litert/vendors/qualcomm:__subpackages__"],
+)
+
+cc_test(
+    name = "op_wrapper_test",
+    srcs = [
+        "op_wrapper_test.cc",
+    ],
+    deps = [
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:param_wrapper",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "tensor_wrapper_test",
+    srcs = [
+        "tensor_wrapper_test.cc",
+    ],
+    deps = [
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "param_wrapper_test",
+    srcs = [
+        "param_wrapper_test.cc",
+    ],
+    deps = [
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:param_wrapper",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "quantize_params_wrapper_test",
+    srcs = [
+        "quantize_params_wrapper_test.cc",
+    ],
+    deps = [
+        "//tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers:quantize_params_wrapper",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tests/op_wrapper_test.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tests/op_wrapper_test.cc
@@ -1,0 +1,226 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+
+#include <gtest/gtest.h>
+
+#include <numeric>
+
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/param_wrapper.h"
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+namespace {
+
+void EXPECT_TENSOR_EQ(Qnn_Tensor_t actual, Qnn_Tensor_t expected) {
+  EXPECT_EQ(actual.v2.id, expected.v2.id);
+  EXPECT_EQ(actual.v2.type, expected.v2.type);
+  EXPECT_EQ(actual.v2.dataFormat, expected.v2.dataFormat);
+  EXPECT_EQ(actual.v2.dataType, expected.v2.dataType);
+  EXPECT_EQ(actual.v2.quantizeParams.encodingDefinition,
+            expected.v2.quantizeParams.encodingDefinition);
+  EXPECT_EQ(actual.v2.rank, expected.v2.rank);
+  for (size_t i = 0; i < actual.v2.rank; i++) {
+    EXPECT_EQ(actual.v2.dimensions[i], expected.v2.dimensions[i]);
+  }
+  EXPECT_EQ(actual.v2.memType, expected.v2.memType);
+  EXPECT_EQ(actual.v2.clientBuf.dataSize, expected.v2.clientBuf.dataSize);
+  const auto* actual_data =
+      reinterpret_cast<const std::uint8_t*>(actual.v2.clientBuf.data);
+  const auto* expected_data =
+      reinterpret_cast<const std::uint8_t*>(expected.v2.clientBuf.data);
+  for (size_t i = 0; i < actual.v2.clientBuf.dataSize; i++) {
+    EXPECT_EQ(actual_data[i], expected_data[i]);
+  }
+}
+
+TEST(OpWrapperTest, SanityTest) {
+  OpWrapper op_wrapper{"name", "OP_TYPE"};
+  const Qnn_OpConfig_t& op_config = op_wrapper.GetOpConfig();
+  EXPECT_EQ(op_config.version, QNN_OPCONFIG_VERSION_1);
+
+  const Qnn_OpConfigV1_t& op_config_v1 = op_config.v1;
+  EXPECT_STREQ(op_config_v1.typeName, "OP_TYPE");
+  EXPECT_STREQ(op_config_v1.packageName, QNN_OP_PACKAGE_NAME_QTI_AISW);
+  EXPECT_STREQ(op_config_v1.name, "name");
+  EXPECT_EQ(op_config_v1.numOfInputs, 0);
+  EXPECT_EQ(op_config_v1.numOfOutputs, 0);
+  EXPECT_EQ(op_config_v1.numOfParams, 0);
+  EXPECT_EQ(op_config_v1.params, nullptr);
+  EXPECT_EQ(op_config_v1.inputTensors, nullptr);
+  EXPECT_EQ(op_config_v1.outputTensors, nullptr);
+}
+
+TEST(OpWrapperTest, CopyCtorSanityTest) {
+  OpWrapper op_wrapper{"name", "OP_TYPE"};
+  OpWrapper copied{op_wrapper};
+  const Qnn_OpConfig_t& op_config = copied.GetOpConfig();
+  EXPECT_EQ(op_config.version, QNN_OPCONFIG_VERSION_1);
+
+  const Qnn_OpConfigV1_t& op_config_v1 = op_config.v1;
+  EXPECT_STREQ(op_config_v1.typeName, "OP_TYPE");
+  EXPECT_STREQ(op_config_v1.packageName, QNN_OP_PACKAGE_NAME_QTI_AISW);
+  EXPECT_STREQ(op_config_v1.name, "name");
+  EXPECT_EQ(op_config_v1.numOfInputs, 0);
+  EXPECT_EQ(op_config_v1.numOfOutputs, 0);
+  EXPECT_EQ(op_config_v1.numOfParams, 0);
+  EXPECT_EQ(op_config_v1.params, nullptr);
+  EXPECT_EQ(op_config_v1.inputTensors, nullptr);
+  EXPECT_EQ(op_config_v1.outputTensors, nullptr);
+}
+
+TEST(OpWrapperTest, MoveCtorSanityTest) {
+  OpWrapper op_wrapper{"name", "OP_TYPE"};
+  OpWrapper moved{std::move(op_wrapper)};
+  const Qnn_OpConfig_t& op_config = moved.GetOpConfig();
+  EXPECT_EQ(op_config.version, QNN_OPCONFIG_VERSION_1);
+
+  const Qnn_OpConfigV1_t& op_config_v1 = op_config.v1;
+  EXPECT_STREQ(op_config_v1.typeName, "OP_TYPE");
+  EXPECT_STREQ(op_config_v1.packageName, QNN_OP_PACKAGE_NAME_QTI_AISW);
+  EXPECT_STREQ(op_config_v1.name, "name");
+  EXPECT_EQ(op_config_v1.numOfInputs, 0);
+  EXPECT_EQ(op_config_v1.numOfOutputs, 0);
+  EXPECT_EQ(op_config_v1.numOfParams, 0);
+  EXPECT_EQ(op_config_v1.params, nullptr);
+  EXPECT_EQ(op_config_v1.inputTensors, nullptr);
+  EXPECT_EQ(op_config_v1.outputTensors, nullptr);
+}
+
+TEST(OpWrapperTest, OpConfigTest) {
+  std::vector<std::uint32_t> dummy_dims = {1, 1, 3};
+  std::vector<std::uint8_t> data = {1, 2, 3};
+  void* data_ptr = reinterpret_cast<void*>(data.data());
+  const auto data_size =
+      std::accumulate(dummy_dims.begin(), dummy_dims.end(),
+                      sizeof(decltype(data)::value_type), std::multiplies<>());
+
+  TensorWrapper tensor_wrapper{0,
+                               QNN_TENSOR_TYPE_APP_WRITE,
+                               QNN_DATATYPE_UFIXED_POINT_8,
+                               QuantizeParamsWrapperVariant(),
+                               dummy_dims,
+                               static_cast<uint32_t>(data_size),
+                               data_ptr};
+
+  Qnn_Tensor_t golden_qnn_tensor;
+  tensor_wrapper.CloneTo(golden_qnn_tensor);
+
+  std::uint8_t value = 255;
+  OpWrapper op_wrapper{"name", "OP_TYPE"};
+  op_wrapper.AddInputTensor(tensor_wrapper);
+  op_wrapper.AddOutputTensor(tensor_wrapper);
+  op_wrapper.AddScalarParam("uint8_param", value, false);
+  op_wrapper.AddTensorParam("tensor_param", tensor_wrapper);
+
+  Qnn_OpConfig_t op_config = op_wrapper.GetOpConfig();
+  EXPECT_EQ(op_config.version, QNN_OPCONFIG_VERSION_1);
+  EXPECT_STREQ(op_config.v1.typeName, "OP_TYPE");
+  EXPECT_STREQ(op_config.v1.packageName, QNN_OP_PACKAGE_NAME_QTI_AISW);
+  EXPECT_STREQ(op_config.v1.name, "name");
+
+  Qnn_OpConfigV1_t op_config_v1 = op_config.v1;
+
+  EXPECT_EQ(op_config_v1.numOfInputs, 1);
+  EXPECT_EQ(op_config_v1.numOfOutputs, 1);
+  EXPECT_EQ(op_config_v1.numOfParams, 2);
+  EXPECT_TENSOR_EQ(op_config_v1.inputTensors[0], golden_qnn_tensor);
+  EXPECT_TENSOR_EQ(op_config_v1.outputTensors[0], golden_qnn_tensor);
+  EXPECT_EQ(op_config_v1.params[0].paramType, QNN_PARAMTYPE_SCALAR);
+  EXPECT_EQ(op_config_v1.params[0].name, "uint8_param");
+  EXPECT_EQ(op_config_v1.params[0].scalarParam.dataType, QNN_DATATYPE_UINT_8);
+  EXPECT_EQ(op_config_v1.params[0].scalarParam.uint8Value, value);
+  EXPECT_EQ(op_config_v1.params[1].paramType, QNN_PARAMTYPE_TENSOR);
+  EXPECT_EQ(op_config_v1.params[1].name, "tensor_param");
+  EXPECT_TENSOR_EQ(op_config_v1.params[1].tensorParam, golden_qnn_tensor);
+}
+
+TEST(OpWrapperTest, CopyConstructorTest) {
+  std::vector<std::uint32_t> dummy_dims = {1, 1, 3};
+  std::vector<std::uint8_t> data = {1, 2, 3};
+  void* data_ptr = reinterpret_cast<void*>(data.data());
+  TensorWrapper tensor_wrapper{0,
+                               QNN_TENSOR_TYPE_APP_WRITE,
+                               QNN_DATATYPE_UFIXED_POINT_8,
+                               QuantizeParamsWrapperVariant(),
+                               dummy_dims,
+                               static_cast<uint32_t>(data.size()),
+                               data_ptr};
+  const auto data_size = std::accumulate(
+      tensor_wrapper.GetDims().begin(), tensor_wrapper.GetDims().end(),
+      GetDataTypeSize(tensor_wrapper.GetDataType()), std::multiplies<>());
+  Qnn_Tensor_t golden_qnn_tensor;
+  tensor_wrapper.CloneTo(golden_qnn_tensor);
+  std::uint8_t value = 255;
+  OpWrapper op_wrapper{"name", "OP_TYPE"};
+  op_wrapper.AddInputTensor(tensor_wrapper);
+  op_wrapper.AddOutputTensor(tensor_wrapper);
+  op_wrapper.AddScalarParam("uint8_param", value, false);
+  op_wrapper.AddTensorParam("tensor_param", tensor_wrapper);
+  OpWrapper op_wrapper_copy(op_wrapper);
+  Qnn_OpConfig_t op_config = op_wrapper_copy.GetOpConfig();
+  EXPECT_EQ(op_config.version, QNN_OPCONFIG_VERSION_1);
+  EXPECT_STREQ(op_config.v1.typeName, "OP_TYPE");
+  EXPECT_STREQ(op_config.v1.packageName, QNN_OP_PACKAGE_NAME_QTI_AISW);
+  EXPECT_STREQ(op_config.v1.name, "name");
+  Qnn_OpConfigV1_t op_config_v1 = op_config.v1;
+  EXPECT_EQ(op_config_v1.numOfInputs, 1);
+  EXPECT_EQ(op_config_v1.numOfOutputs, 1);
+  EXPECT_EQ(op_config_v1.numOfParams, 2);
+  EXPECT_TENSOR_EQ(op_config_v1.inputTensors[0], golden_qnn_tensor);
+  EXPECT_TENSOR_EQ(op_config_v1.outputTensors[0], golden_qnn_tensor);
+  EXPECT_EQ(op_config_v1.params[0].paramType, QNN_PARAMTYPE_SCALAR);
+  EXPECT_EQ(op_config_v1.params[0].name, "uint8_param");
+  EXPECT_EQ(op_config_v1.params[0].scalarParam.dataType, QNN_DATATYPE_UINT_8);
+  EXPECT_EQ(op_config_v1.params[0].scalarParam.uint8Value, value);
+  EXPECT_EQ(op_config_v1.params[1].paramType, QNN_PARAMTYPE_TENSOR);
+  EXPECT_EQ(op_config_v1.params[1].name, "tensor_param");
+  EXPECT_TENSOR_EQ(op_config_v1.params[1].tensorParam, golden_qnn_tensor);
+}
+
+TEST(OpWrapperTest, MoveConstructorTest) {
+  std::vector<std::uint32_t> dummy_dims = {1, 1, 3};
+  std::vector<std::uint8_t> data = {1, 2, 3};
+  void* data_ptr = reinterpret_cast<void*>(data.data());
+  TensorWrapper tensor_wrapper{0,
+                               QNN_TENSOR_TYPE_APP_WRITE,
+                               QNN_DATATYPE_UFIXED_POINT_8,
+                               QuantizeParamsWrapperVariant(),
+                               dummy_dims,
+                               static_cast<uint32_t>(data.size()),
+                               data_ptr};
+  const auto data_size = std::accumulate(
+      tensor_wrapper.GetDims().begin(), tensor_wrapper.GetDims().end(),
+      GetDataTypeSize(tensor_wrapper.GetDataType()), std::multiplies<>());
+  Qnn_Tensor_t golden_qnn_tensor;
+  tensor_wrapper.CloneTo(golden_qnn_tensor);
+  std::uint8_t value = 255;
+  OpWrapper op_wrapper{"name", "OP_TYPE"};
+  op_wrapper.AddInputTensor(tensor_wrapper);
+  op_wrapper.AddOutputTensor(tensor_wrapper);
+  op_wrapper.AddScalarParam("uint8_param", value, false);
+  op_wrapper.AddTensorParam("tensor_param", tensor_wrapper);
+  OpWrapper op_wrapper_move(std::move(op_wrapper));
+  Qnn_OpConfig_t op_config = op_wrapper_move.GetOpConfig();
+  EXPECT_EQ(op_config.version, QNN_OPCONFIG_VERSION_1);
+  EXPECT_STREQ(op_config.v1.typeName, "OP_TYPE");
+  EXPECT_STREQ(op_config.v1.packageName, QNN_OP_PACKAGE_NAME_QTI_AISW);
+  EXPECT_STREQ(op_config.v1.name, "name");
+  Qnn_OpConfigV1_t op_config_v1 = op_config.v1;
+  EXPECT_EQ(op_config_v1.numOfInputs, 1);
+  EXPECT_EQ(op_config_v1.numOfOutputs, 1);
+  EXPECT_EQ(op_config_v1.numOfParams, 2);
+  EXPECT_TENSOR_EQ(op_config_v1.inputTensors[0], golden_qnn_tensor);
+  EXPECT_TENSOR_EQ(op_config_v1.outputTensors[0], golden_qnn_tensor);
+  EXPECT_EQ(op_config_v1.params[0].paramType, QNN_PARAMTYPE_SCALAR);
+  EXPECT_EQ(op_config_v1.params[0].name, "uint8_param");
+  EXPECT_EQ(op_config_v1.params[0].scalarParam.dataType, QNN_DATATYPE_UINT_8);
+  EXPECT_EQ(op_config_v1.params[0].scalarParam.uint8Value, value);
+  EXPECT_EQ(op_config_v1.params[1].paramType, QNN_PARAMTYPE_TENSOR);
+  EXPECT_EQ(op_config_v1.params[1].name, "tensor_param");
+  EXPECT_TENSOR_EQ(op_config_v1.params[1].tensorParam, golden_qnn_tensor);
+}
+
+}  // namespace
+}  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tests/param_wrapper_test.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tests/param_wrapper_test.cc
@@ -1,0 +1,227 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/param_wrapper.h"
+
+#include <gtest/gtest.h>
+
+#include <numeric>
+
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+namespace {
+
+TEST(ScalarParamWrapperTest, BoolParamTest) {
+  ScalarParamWrapper bool_param{"bool_param", true, false};
+  Qnn_Param_t bool_qnn_param = QNN_PARAM_INIT;
+  bool_param.CloneTo(bool_qnn_param);
+  EXPECT_EQ(bool_qnn_param.paramType, QNN_PARAMTYPE_SCALAR);
+  EXPECT_EQ(bool_qnn_param.name, "bool_param");
+  EXPECT_EQ(bool_qnn_param.scalarParam.dataType, QNN_DATATYPE_BOOL_8);
+  EXPECT_EQ(bool_qnn_param.scalarParam.bool8Value, 1);
+}
+
+TEST(ScalarParamWrapperTest, Uint8ParamTest) {
+  std::uint8_t value = 255;
+  ScalarParamWrapper uint8_param{"uint8_param", value, false};
+  Qnn_Param_t uint8_qnn_param = QNN_PARAM_INIT;
+  uint8_param.CloneTo(uint8_qnn_param);
+  EXPECT_EQ(uint8_qnn_param.paramType, QNN_PARAMTYPE_SCALAR);
+  EXPECT_EQ(uint8_qnn_param.name, "uint8_param");
+  EXPECT_EQ(uint8_qnn_param.scalarParam.dataType, QNN_DATATYPE_UINT_8);
+  EXPECT_EQ(uint8_qnn_param.scalarParam.uint8Value, value);
+}
+
+TEST(ScalarParamWrapperTest, Int8ParamTest) {
+  std::int8_t value = -128;
+  ScalarParamWrapper int8_param{"int8_param", value, false};
+  Qnn_Param_t int8_qnn_param = QNN_PARAM_INIT;
+  int8_param.CloneTo(int8_qnn_param);
+  EXPECT_EQ(int8_qnn_param.paramType, QNN_PARAMTYPE_SCALAR);
+  EXPECT_EQ(int8_qnn_param.name, "int8_param");
+  EXPECT_EQ(int8_qnn_param.scalarParam.dataType, QNN_DATATYPE_INT_8);
+  EXPECT_EQ(int8_qnn_param.scalarParam.int8Value, value);
+}
+
+TEST(ScalarParamWrapperTest, Uint16ParamTest) {
+  std::uint16_t value = 65535;
+  ScalarParamWrapper uint16_param{"uint16_param", value, false};
+  Qnn_Param_t uint16_qnn_param = QNN_PARAM_INIT;
+  uint16_param.CloneTo(uint16_qnn_param);
+  EXPECT_EQ(uint16_qnn_param.paramType, QNN_PARAMTYPE_SCALAR);
+  EXPECT_EQ(uint16_qnn_param.name, "uint16_param");
+  EXPECT_EQ(uint16_qnn_param.scalarParam.dataType, QNN_DATATYPE_UINT_16);
+  EXPECT_EQ(uint16_qnn_param.scalarParam.uint16Value, value);
+}
+
+TEST(ScalarParamWrapperTest, Int16ParamTest) {
+  std::int16_t value = -32768;
+  ScalarParamWrapper int16_param{"int16_param", value, false};
+  Qnn_Param_t int16_qnn_param = QNN_PARAM_INIT;
+  int16_param.CloneTo(int16_qnn_param);
+  EXPECT_EQ(int16_qnn_param.paramType, QNN_PARAMTYPE_SCALAR);
+  EXPECT_EQ(int16_qnn_param.name, "int16_param");
+  EXPECT_EQ(int16_qnn_param.scalarParam.dataType, QNN_DATATYPE_INT_16);
+  EXPECT_EQ(int16_qnn_param.scalarParam.int16Value, value);
+}
+
+TEST(ScalarParamWrapperTest, Uint32ParamTest) {
+  std::uint32_t value = 4294967295;
+  ScalarParamWrapper uint32_param{"uint32_param", value, false};
+  Qnn_Param_t uint32_qnn_param = QNN_PARAM_INIT;
+  uint32_param.CloneTo(uint32_qnn_param);
+  EXPECT_EQ(uint32_qnn_param.paramType, QNN_PARAMTYPE_SCALAR);
+  EXPECT_EQ(uint32_qnn_param.name, "uint32_param");
+  EXPECT_EQ(uint32_qnn_param.scalarParam.dataType, QNN_DATATYPE_UINT_32);
+  EXPECT_EQ(uint32_qnn_param.scalarParam.uint32Value, value);
+}
+
+TEST(ScalarParamWrapperTest, Int32ParamTest) {
+  std::int32_t value = -2147483648;
+  ScalarParamWrapper int32_param{"int32_param", value, false};
+  Qnn_Param_t int32_qnn_param = QNN_PARAM_INIT;
+  int32_param.CloneTo(int32_qnn_param);
+  EXPECT_EQ(int32_qnn_param.paramType, QNN_PARAMTYPE_SCALAR);
+  EXPECT_EQ(int32_qnn_param.name, "int32_param");
+  EXPECT_EQ(int32_qnn_param.scalarParam.dataType, QNN_DATATYPE_INT_32);
+  EXPECT_EQ(int32_qnn_param.scalarParam.int32Value, value);
+}
+
+TEST(ScalarParamWrapperTest, FloatParamTest) {
+  float value = 3.14f;
+  ScalarParamWrapper float_param{"float_param", value, false};
+  Qnn_Param_t float_qnn_param = QNN_PARAM_INIT;
+  float_param.CloneTo(float_qnn_param);
+  EXPECT_EQ(float_qnn_param.paramType, QNN_PARAMTYPE_SCALAR);
+  EXPECT_EQ(float_qnn_param.name, "float_param");
+  EXPECT_EQ(float_qnn_param.scalarParam.dataType, QNN_DATATYPE_FLOAT_32);
+  EXPECT_FLOAT_EQ(float_qnn_param.scalarParam.floatValue, value);
+}
+
+TEST(ScalarParamWrapperTest, QuantizedBoolParamTest) {
+  ScalarParamWrapper bool_quant_param{"bool_quant_param", true, true};
+  Qnn_Param_t bool_quant_qnn_param = QNN_PARAM_INIT;
+  bool_quant_param.CloneTo(bool_quant_qnn_param);
+  EXPECT_EQ(bool_quant_qnn_param.paramType, QNN_PARAMTYPE_SCALAR);
+  EXPECT_EQ(bool_quant_qnn_param.name, "bool_quant_param");
+  EXPECT_EQ(bool_quant_qnn_param.scalarParam.dataType, QNN_DATATYPE_BOOL_8);
+  EXPECT_EQ(bool_quant_qnn_param.scalarParam.bool8Value, 1);
+}
+
+TEST(ScalarParamWrapperTest, QuantizedUint8ParamTest) {
+  std::uint8_t value = 255;
+  ScalarParamWrapper uint8_quant_param{"uint8_quant_param", value, true};
+  Qnn_Param_t uint8_quant_qnn_param = QNN_PARAM_INIT;
+  uint8_quant_param.CloneTo(uint8_quant_qnn_param);
+  EXPECT_EQ(uint8_quant_qnn_param.paramType, QNN_PARAMTYPE_SCALAR);
+  EXPECT_EQ(uint8_quant_qnn_param.name, "uint8_quant_param");
+  EXPECT_EQ(uint8_quant_qnn_param.scalarParam.dataType,
+            QNN_DATATYPE_UFIXED_POINT_8);
+  EXPECT_EQ(uint8_quant_qnn_param.scalarParam.uint8Value, value);
+}
+
+TEST(ScalarParamWrapperTest, QuantizedInt8ParamTest) {
+  std::int8_t value = -128;
+  ScalarParamWrapper int8_quant_param{"int8_quant_param", value, true};
+  Qnn_Param_t int8_quant_qnn_param = QNN_PARAM_INIT;
+  int8_quant_param.CloneTo(int8_quant_qnn_param);
+  EXPECT_EQ(int8_quant_qnn_param.paramType, QNN_PARAMTYPE_SCALAR);
+  EXPECT_EQ(int8_quant_qnn_param.name, "int8_quant_param");
+  EXPECT_EQ(int8_quant_qnn_param.scalarParam.dataType,
+            QNN_DATATYPE_SFIXED_POINT_8);
+  EXPECT_EQ(int8_quant_qnn_param.scalarParam.int8Value, value);
+}
+
+TEST(ScalarParamWrapperTest, QuantizedUint16ParamTest) {
+  std::uint16_t value = 65535;
+  ScalarParamWrapper uint16_quant_param{"uint16_quant_param", value, true};
+  Qnn_Param_t uint16_quant_qnn_param = QNN_PARAM_INIT;
+  uint16_quant_param.CloneTo(uint16_quant_qnn_param);
+  EXPECT_EQ(uint16_quant_qnn_param.paramType, QNN_PARAMTYPE_SCALAR);
+  EXPECT_EQ(uint16_quant_qnn_param.name, "uint16_quant_param");
+  EXPECT_EQ(uint16_quant_qnn_param.scalarParam.dataType,
+            QNN_DATATYPE_UFIXED_POINT_16);
+  EXPECT_EQ(uint16_quant_qnn_param.scalarParam.uint16Value, value);
+}
+
+TEST(ScalarParamWrapperTest, QuantizedInt16ParamTest) {
+  std::int16_t value = -32768;
+  ScalarParamWrapper int16_quant_param{"int16_quant_param", value, true};
+  Qnn_Param_t int16_quant_qnn_param = QNN_PARAM_INIT;
+  int16_quant_param.CloneTo(int16_quant_qnn_param);
+  EXPECT_EQ(int16_quant_qnn_param.paramType, QNN_PARAMTYPE_SCALAR);
+  EXPECT_EQ(int16_quant_qnn_param.name, "int16_quant_param");
+  EXPECT_EQ(int16_quant_qnn_param.scalarParam.dataType,
+            QNN_DATATYPE_SFIXED_POINT_16);
+  EXPECT_EQ(int16_quant_qnn_param.scalarParam.int16Value, value);
+}
+
+TEST(ScalarParamWrapperTest, QuantizedUint32ParamTest) {
+  std::uint32_t value = 4294967295;
+  ScalarParamWrapper uint32_quant_param{"uint32_quant_param", value, true};
+  Qnn_Param_t uint32_quant_qnn_param = QNN_PARAM_INIT;
+  uint32_quant_param.CloneTo(uint32_quant_qnn_param);
+  EXPECT_EQ(uint32_quant_qnn_param.paramType, QNN_PARAMTYPE_SCALAR);
+  EXPECT_EQ(uint32_quant_qnn_param.name, "uint32_quant_param");
+  EXPECT_EQ(uint32_quant_qnn_param.scalarParam.dataType,
+            QNN_DATATYPE_UFIXED_POINT_32);
+  EXPECT_EQ(uint32_quant_qnn_param.scalarParam.uint32Value, value);
+}
+
+TEST(ScalarParamWrapperTest, QuantizedInt32ParamTest) {
+  std::int32_t value = -2147483648;
+  ScalarParamWrapper int32_quant_param{"int32_quant_param", value, true};
+  Qnn_Param_t int32_quant_qnn_param = QNN_PARAM_INIT;
+  int32_quant_param.CloneTo(int32_quant_qnn_param);
+  EXPECT_EQ(int32_quant_qnn_param.paramType, QNN_PARAMTYPE_SCALAR);
+  EXPECT_EQ(int32_quant_qnn_param.name, "int32_quant_param");
+  EXPECT_EQ(int32_quant_qnn_param.scalarParam.dataType,
+            QNN_DATATYPE_SFIXED_POINT_32);
+  EXPECT_EQ(int32_quant_qnn_param.scalarParam.int32Value, value);
+}
+
+TEST(ParamWrapperTest, TensorParamTest) {
+  std::vector<std::uint32_t> dummy_dims = {1, 1, 3};
+  std::vector<std::uint8_t> data = {1, 2, 3};
+  void* data_ptr = reinterpret_cast<void*>(data.data());
+
+  const auto data_size =
+      std::accumulate(dummy_dims.begin(), dummy_dims.end(),
+                      sizeof(decltype(data)::value_type), std::multiplies<>());
+
+  TensorWrapper tensor_wrapper{0,
+                               QNN_TENSOR_TYPE_STATIC,
+                               QNN_DATATYPE_UFIXED_POINT_8,
+                               QuantizeParamsWrapperVariant(),
+                               dummy_dims,
+                               static_cast<uint32_t>(data_size),
+                               data_ptr};
+
+  TensorParamWrapper tensor_param{"tensor_param", tensor_wrapper};
+
+  Qnn_Param_t qnn_tensor_param = QNN_PARAM_INIT;
+  tensor_param.CloneTo(qnn_tensor_param);
+  EXPECT_EQ(qnn_tensor_param.paramType, QNN_PARAMTYPE_TENSOR);
+  EXPECT_EQ(qnn_tensor_param.name, "tensor_param");
+
+  Qnn_Tensor_t& ref = qnn_tensor_param.tensorParam;
+  EXPECT_EQ(ref.v2.id, 0);
+  EXPECT_EQ(ref.v2.type, QNN_TENSOR_TYPE_STATIC);
+  EXPECT_EQ(ref.v2.dataFormat, QNN_TENSOR_DATA_FORMAT_FLAT_BUFFER);
+  EXPECT_EQ(ref.v2.dataType, QNN_DATATYPE_UFIXED_POINT_8);
+  EXPECT_EQ(ref.v2.quantizeParams.encodingDefinition, QNN_DEFINITION_UNDEFINED);
+  EXPECT_EQ(ref.v2.rank, dummy_dims.size());
+  for (size_t i = 0; i < ref.v2.rank; i++) {
+    EXPECT_EQ(ref.v2.dimensions[i], dummy_dims[i]);
+  }
+  EXPECT_EQ(ref.v2.memType, QNN_TENSORMEMTYPE_RAW);
+  EXPECT_EQ(ref.v2.clientBuf.dataSize, data_size);
+  const auto* ref_data =
+      reinterpret_cast<const std::uint8_t*>(ref.v2.clientBuf.data);
+  for (size_t i = 0; i < data.size(); i++) {
+    EXPECT_EQ(ref_data[i], data[i]);
+  }
+}
+}  // namespace
+}  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tests/quantize_params_wrapper_test.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tests/quantize_params_wrapper_test.cc
@@ -1,0 +1,137 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h"
+
+#include <gtest/gtest.h>
+
+namespace qnn {
+namespace {
+
+TEST(UndefinedQuantizeParamsWrapperTest, DefaultConstructorTest) {
+  UndefinedQuantizeParamsWrapper wrapper;
+  Qnn_QuantizeParams_t dst = QNN_QUANTIZE_PARAMS_INIT;
+  wrapper.CloneTo(dst);
+  EXPECT_EQ(dst.encodingDefinition, QNN_DEFINITION_UNDEFINED);
+  EXPECT_EQ(dst.quantizationEncoding, QNN_QUANTIZATION_ENCODING_UNDEFINED);
+}
+
+TEST(UndefinedQuantizeParamsWrapperTest, CopyConstructorTest) {
+  UndefinedQuantizeParamsWrapper wrapper1;
+  UndefinedQuantizeParamsWrapper wrapper2(wrapper1);
+  Qnn_QuantizeParams_t dst = QNN_QUANTIZE_PARAMS_INIT;
+  wrapper2.CloneTo(dst);
+  EXPECT_EQ(dst.encodingDefinition, QNN_DEFINITION_UNDEFINED);
+  EXPECT_EQ(dst.quantizationEncoding, QNN_QUANTIZATION_ENCODING_UNDEFINED);
+}
+
+TEST(UndefinedQuantizeParamsWrapperTest, MoveConstructorTest) {
+  UndefinedQuantizeParamsWrapper wrapper1;
+  UndefinedQuantizeParamsWrapper wrapper2(std::move(wrapper1));
+  Qnn_QuantizeParams_t dst = QNN_QUANTIZE_PARAMS_INIT;
+  wrapper2.CloneTo(dst);
+  EXPECT_EQ(dst.encodingDefinition, QNN_DEFINITION_UNDEFINED);
+  EXPECT_EQ(dst.quantizationEncoding, QNN_QUANTIZATION_ENCODING_UNDEFINED);
+}
+
+TEST(ScaleOffsetQuantizeParamsWrapperTest, ConstructorTest) {
+  float scale = 1.5f;
+  std::int32_t zero_point = 10;
+  ScaleOffsetQuantizeParamsWrapper wrapper(scale, zero_point);
+  Qnn_QuantizeParams_t dst = QNN_QUANTIZE_PARAMS_INIT;
+  wrapper.CloneTo(dst);
+  EXPECT_EQ(dst.encodingDefinition, QNN_DEFINITION_DEFINED);
+  EXPECT_EQ(dst.quantizationEncoding, QNN_QUANTIZATION_ENCODING_SCALE_OFFSET);
+  EXPECT_FLOAT_EQ(dst.scaleOffsetEncoding.scale, scale);
+  EXPECT_EQ(dst.scaleOffsetEncoding.offset, -zero_point);
+}
+
+TEST(ScaleOffsetQuantizeParamsWrapperTest, CopyConstructorTest) {
+  float scale = 1.5f;
+  std::int32_t zero_point = 10;
+  ScaleOffsetQuantizeParamsWrapper wrapper1(scale, zero_point);
+  ScaleOffsetQuantizeParamsWrapper wrapper2(wrapper1);
+  Qnn_QuantizeParams_t dst = QNN_QUANTIZE_PARAMS_INIT;
+  wrapper2.CloneTo(dst);
+  EXPECT_EQ(dst.encodingDefinition, QNN_DEFINITION_DEFINED);
+  EXPECT_EQ(dst.quantizationEncoding, QNN_QUANTIZATION_ENCODING_SCALE_OFFSET);
+  EXPECT_FLOAT_EQ(dst.scaleOffsetEncoding.scale, scale);
+  EXPECT_EQ(dst.scaleOffsetEncoding.offset, -zero_point);
+}
+
+TEST(ScaleOffsetQuantizeParamsWrapperTest, MoveConstructorTest) {
+  float scale = 1.5f;
+  std::int32_t zero_point = 10;
+  ScaleOffsetQuantizeParamsWrapper wrapper1(scale, zero_point);
+  ScaleOffsetQuantizeParamsWrapper wrapper2(std::move(wrapper1));
+  Qnn_QuantizeParams_t dst = QNN_QUANTIZE_PARAMS_INIT;
+  wrapper2.CloneTo(dst);
+  EXPECT_EQ(dst.encodingDefinition, QNN_DEFINITION_DEFINED);
+  EXPECT_EQ(dst.quantizationEncoding, QNN_QUANTIZATION_ENCODING_SCALE_OFFSET);
+  EXPECT_FLOAT_EQ(dst.scaleOffsetEncoding.scale, scale);
+  EXPECT_EQ(dst.scaleOffsetEncoding.offset, -zero_point);
+}
+
+TEST(AxisScaleOffsetQuantizeParamsWrapperTest, ConstructorTest) {
+  std::int32_t axis = 1;
+  std::vector<float> scales = {1.5f, 2.5f};
+  std::vector<std::int32_t> zero_points = {10, 20};
+  AxisScaleOffsetQuantizeParamsWrapper wrapper(axis, scales, zero_points);
+  Qnn_QuantizeParams_t dst = QNN_QUANTIZE_PARAMS_INIT;
+  wrapper.CloneTo(dst);
+  EXPECT_EQ(dst.encodingDefinition, QNN_DEFINITION_DEFINED);
+  EXPECT_EQ(dst.quantizationEncoding,
+            QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET);
+  EXPECT_EQ(dst.axisScaleOffsetEncoding.axis, axis);
+  EXPECT_EQ(dst.axisScaleOffsetEncoding.numScaleOffsets, scales.size());
+  for (size_t i = 0; i < scales.size(); ++i) {
+    EXPECT_FLOAT_EQ(dst.axisScaleOffsetEncoding.scaleOffset[i].scale,
+                    scales[i]);
+    EXPECT_EQ(dst.axisScaleOffsetEncoding.scaleOffset[i].offset,
+              -zero_points[i]);
+  }
+}
+
+TEST(AxisScaleOffsetQuantizeParamsWrapperTest, CopyConstructorTest) {
+  std::int32_t axis = 1;
+  std::vector<float> scales = {1.5f, 2.5f};
+  std::vector<std::int32_t> zero_points = {10, 20};
+  AxisScaleOffsetQuantizeParamsWrapper wrapper1(axis, scales, zero_points);
+  AxisScaleOffsetQuantizeParamsWrapper wrapper2(wrapper1);
+  Qnn_QuantizeParams_t dst = QNN_QUANTIZE_PARAMS_INIT;
+  wrapper2.CloneTo(dst);
+  EXPECT_EQ(dst.encodingDefinition, QNN_DEFINITION_DEFINED);
+  EXPECT_EQ(dst.quantizationEncoding,
+            QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET);
+  EXPECT_EQ(dst.axisScaleOffsetEncoding.axis, axis);
+  EXPECT_EQ(dst.axisScaleOffsetEncoding.numScaleOffsets, scales.size());
+  for (size_t i = 0; i < scales.size(); ++i) {
+    EXPECT_FLOAT_EQ(dst.axisScaleOffsetEncoding.scaleOffset[i].scale,
+                    scales[i]);
+    EXPECT_EQ(dst.axisScaleOffsetEncoding.scaleOffset[i].offset,
+              -zero_points[i]);
+  }
+}
+
+TEST(AxisScaleOffsetQuantizeParamsWrapperTest, MoveConstructorTest) {
+  std::int32_t axis = 1;
+  std::vector<float> scales = {1.5f, 2.5f};
+  std::vector<std::int32_t> zero_points = {10, 20};
+  AxisScaleOffsetQuantizeParamsWrapper wrapper1(axis, scales, zero_points);
+  AxisScaleOffsetQuantizeParamsWrapper wrapper2(std::move(wrapper1));
+  Qnn_QuantizeParams_t dst = QNN_QUANTIZE_PARAMS_INIT;
+  wrapper2.CloneTo(dst);
+  EXPECT_EQ(dst.encodingDefinition, QNN_DEFINITION_DEFINED);
+  EXPECT_EQ(dst.quantizationEncoding,
+            QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET);
+  EXPECT_EQ(dst.axisScaleOffsetEncoding.axis, axis);
+  EXPECT_EQ(dst.axisScaleOffsetEncoding.numScaleOffsets, scales.size());
+  for (size_t i = 0; i < scales.size(); ++i) {
+    EXPECT_FLOAT_EQ(dst.axisScaleOffsetEncoding.scaleOffset[i].scale,
+                    scales[i]);
+    EXPECT_EQ(dst.axisScaleOffsetEncoding.scaleOffset[i].offset,
+              -zero_points[i]);
+  }
+}
+}  // namespace
+}  // namespace qnn

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tests/tensor_wrapper_test.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tests/tensor_wrapper_test.cc
@@ -1,0 +1,276 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+#include <gtest/gtest.h>
+
+#include <numeric>
+#include <optional>
+
+namespace qnn {
+namespace {
+
+TEST(TensorWrapperTest, SanityTest) {
+  TensorWrapper tensor_wrapper{};
+
+  EXPECT_EQ(tensor_wrapper.GetRank(), 0);
+  EXPECT_TRUE(tensor_wrapper.GetDims().empty());
+  EXPECT_TRUE(std::holds_alternative<UndefinedQuantizeParamsWrapper>(
+      tensor_wrapper.GetQuantParams()));
+  EXPECT_FALSE(tensor_wrapper.IsPerTensorQuantWithOffsetDiff(tensor_wrapper));
+  EXPECT_FALSE(tensor_wrapper.IsQuant8());
+  EXPECT_FALSE(tensor_wrapper.IsQuant16());
+  EXPECT_EQ(tensor_wrapper.GetDataType(), QNN_DATATYPE_UNDEFINED);
+  EXPECT_FALSE(tensor_wrapper.IsSubgraphInput());
+  EXPECT_FALSE(tensor_wrapper.IsSubgraphOutput());
+  EXPECT_FALSE(tensor_wrapper.IsTensorStatic());
+  EXPECT_EQ(tensor_wrapper.GetStaticTensorData<std::uint8_t>(), std::nullopt);
+  std::vector<std::uint8_t> data = {1, 2, 3};
+  // expect no use, since tensor type not correct
+  tensor_wrapper.SetTensorData<std::uint8_t>(
+      absl::MakeSpan(data.data(), data.size()));
+  EXPECT_EQ(tensor_wrapper.GetStaticTensorData<std::uint8_t>(), std::nullopt);
+}
+
+TEST(TensorWrapperTest, CopyTensorTest) {
+  std::vector<std::uint32_t> dummy_dims = {1, 1, 3};
+  ScaleOffsetQuantizeParamsWrapper q_param(1, 0);
+  TensorWrapper tensor_wrapper{0, QNN_TENSOR_TYPE_STATIC,
+                               QNN_DATATYPE_UFIXED_POINT_8, q_param,
+                               dummy_dims};
+  TensorWrapper copied{tensor_wrapper};
+
+  EXPECT_EQ(copied.GetRank(), 3);
+  EXPECT_EQ(copied.GetDims(), dummy_dims);
+  EXPECT_TRUE(std::holds_alternative<ScaleOffsetQuantizeParamsWrapper>(
+      copied.GetQuantParams()));
+  EXPECT_FALSE(copied.IsPerTensorQuantWithOffsetDiff(copied));
+  EXPECT_TRUE(copied.IsQuant8());
+  EXPECT_FALSE(copied.IsQuant16());
+  EXPECT_EQ(copied.GetDataType(), QNN_DATATYPE_UFIXED_POINT_8);
+  EXPECT_FALSE(copied.IsSubgraphInput());
+  EXPECT_FALSE(copied.IsSubgraphOutput());
+  EXPECT_TRUE(copied.IsTensorStatic());
+  EXPECT_EQ(copied.GetStaticTensorData<std::uint8_t>(), std::nullopt);
+  std::vector<std::uint8_t> data = {1, 2, 3};
+  copied.SetTensorData<std::uint8_t>(absl::MakeSpan(data.data(), data.size()));
+  const auto tensor_data = copied.GetStaticTensorData<std::uint8_t>();
+  EXPECT_TRUE(tensor_data.has_value());
+  for (size_t i = 0; i < data.size(); i++) {
+    EXPECT_EQ((*tensor_data)[i], data[i]);
+  }
+}
+
+TEST(TensorWrapperTest, MoveTensorTest) {
+  std::vector<std::uint32_t> dummy_dims = {1, 1, 3};
+  ScaleOffsetQuantizeParamsWrapper q_param(1, 0);
+  std::vector<std::uint8_t> data = {1, 2, 3};
+  void* data_ptr = reinterpret_cast<void*>(data.data());
+  TensorWrapper tensor_wrapper{0,
+                               QNN_TENSOR_TYPE_STATIC,
+                               QNN_DATATYPE_UFIXED_POINT_8,
+                               q_param,
+                               dummy_dims,
+                               static_cast<uint32_t>(data.size()),
+                               data_ptr};
+  TensorWrapper moved{tensor_wrapper};
+
+  EXPECT_EQ(moved.GetRank(), 3);
+  EXPECT_EQ(moved.GetDims(), dummy_dims);
+  EXPECT_TRUE(std::holds_alternative<ScaleOffsetQuantizeParamsWrapper>(
+      moved.GetQuantParams()));
+  EXPECT_FALSE(moved.IsPerTensorQuantWithOffsetDiff(moved));
+  EXPECT_TRUE(moved.IsQuant8());
+  EXPECT_FALSE(moved.IsQuant16());
+  EXPECT_EQ(moved.GetDataType(), QNN_DATATYPE_UFIXED_POINT_8);
+  EXPECT_FALSE(moved.IsSubgraphInput());
+  EXPECT_FALSE(moved.IsSubgraphOutput());
+  EXPECT_TRUE(moved.IsTensorStatic());
+  const auto tensor_data = moved.GetStaticTensorData<std::uint8_t>();
+  EXPECT_TRUE(tensor_data.has_value());
+  for (size_t i = 0; i < data.size(); i++) {
+    EXPECT_EQ(tensor_data.value()[i], data[i]);
+  }
+}
+
+TEST(TensorWrapperTest, QnnTensorTest) {
+  std::vector<std::uint32_t> dummy_dims = {1, 1, 3};
+  std::vector<std::uint8_t> data = {1, 2, 3};
+  void* data_ptr = reinterpret_cast<void*>(data.data());
+  const auto data_size =
+      std::accumulate(dummy_dims.begin(), dummy_dims.end(),
+                      sizeof(decltype(data)::value_type), std::multiplies<>());
+
+  TensorWrapper tensor_wrapper{0,
+                               QNN_TENSOR_TYPE_APP_WRITE,
+                               QNN_DATATYPE_UFIXED_POINT_8,
+                               QuantizeParamsWrapperVariant(),
+                               dummy_dims,
+                               static_cast<uint32_t>(data_size),
+                               data_ptr};
+
+  Qnn_Tensor_t cloned;
+  tensor_wrapper.CloneTo(cloned);
+  EXPECT_EQ(cloned.version, QNN_TENSOR_VERSION_2);
+  EXPECT_EQ(cloned.v2.id, 0);
+  EXPECT_EQ(cloned.v2.type, QNN_TENSOR_TYPE_APP_WRITE);
+  EXPECT_EQ(cloned.v2.dataFormat, QNN_TENSOR_DATA_FORMAT_FLAT_BUFFER);
+  EXPECT_EQ(cloned.v2.dataType, QNN_DATATYPE_UFIXED_POINT_8);
+  EXPECT_EQ(cloned.v2.quantizeParams.encodingDefinition,
+            QNN_DEFINITION_UNDEFINED);
+  EXPECT_EQ(cloned.v2.rank, dummy_dims.size());
+  for (size_t i = 0; i < cloned.v2.rank; i++) {
+    EXPECT_EQ(cloned.v2.dimensions[i], dummy_dims[i]);
+  }
+  EXPECT_EQ(cloned.v2.memType, QNN_TENSORMEMTYPE_RAW);
+  EXPECT_EQ(cloned.v2.clientBuf.dataSize, data_size);
+  const auto* cloned_data =
+      reinterpret_cast<const std::uint8_t*>(cloned.v2.clientBuf.data);
+  for (size_t i = 0; i < data.size(); i++) {
+    EXPECT_EQ(cloned_data[i], data[i]);
+  }
+
+  Qnn_Tensor_t& ref = tensor_wrapper.GetQnnTensor();
+  EXPECT_EQ(ref.version, QNN_TENSOR_VERSION_2);
+  EXPECT_EQ(ref.v2.id, 0);
+  EXPECT_EQ(ref.v2.type, QNN_TENSOR_TYPE_APP_WRITE);
+  EXPECT_EQ(ref.v2.dataFormat, QNN_TENSOR_DATA_FORMAT_FLAT_BUFFER);
+  EXPECT_EQ(ref.v2.dataType, QNN_DATATYPE_UFIXED_POINT_8);
+  EXPECT_EQ(ref.v2.quantizeParams.encodingDefinition, QNN_DEFINITION_UNDEFINED);
+  EXPECT_EQ(ref.v2.rank, dummy_dims.size());
+  for (size_t i = 0; i < ref.v2.rank; i++) {
+    EXPECT_EQ(ref.v2.dimensions[i], dummy_dims[i]);
+  }
+  EXPECT_EQ(ref.v2.memType, QNN_TENSORMEMTYPE_RAW);
+  EXPECT_EQ(ref.v2.clientBuf.dataSize, data_size);
+  const auto* ref_data =
+      reinterpret_cast<const std::uint8_t*>(ref.v2.clientBuf.data);
+  for (size_t i = 0; i < data.size(); i++) {
+    EXPECT_EQ(ref_data[i], data[i]);
+  }
+}
+
+TEST(TensorWrapperTest, DataTypeTest) {
+  TensorWrapper tensor_wrapper{};
+  tensor_wrapper.SetDataType(QNN_DATATYPE_UFIXED_POINT_8);
+  EXPECT_EQ(tensor_wrapper.GetDataType(), QNN_DATATYPE_UFIXED_POINT_8);
+  EXPECT_TRUE(tensor_wrapper.IsQuant8());
+
+  tensor_wrapper.SetDataType(QNN_DATATYPE_SFIXED_POINT_8);
+  EXPECT_EQ(tensor_wrapper.GetDataType(), QNN_DATATYPE_SFIXED_POINT_8);
+  EXPECT_TRUE(tensor_wrapper.IsQuant8());
+
+  tensor_wrapper.SetDataType(QNN_DATATYPE_UFIXED_POINT_16);
+  EXPECT_EQ(tensor_wrapper.GetDataType(), QNN_DATATYPE_UFIXED_POINT_16);
+  EXPECT_TRUE(tensor_wrapper.IsQuant16());
+
+  tensor_wrapper.SetDataType(QNN_DATATYPE_SFIXED_POINT_16);
+  EXPECT_EQ(tensor_wrapper.GetDataType(), QNN_DATATYPE_SFIXED_POINT_16);
+  EXPECT_TRUE(tensor_wrapper.IsQuant16());
+}
+
+TEST(TensorWrapperTest, IsPerTensorQuantWithOffsetDiff8BitTest) {
+  constexpr int kSUFixed8OffsetDiff = 128;
+  ScaleOffsetQuantizeParamsWrapper wrapper1(1, 0);
+  ScaleOffsetQuantizeParamsWrapper wrapper2(1, kSUFixed8OffsetDiff);
+  TensorWrapper tensor_wrapper0{0,
+                                QNN_TENSOR_TYPE_STATIC,
+                                QNN_DATATYPE_UFIXED_POINT_8,
+                                QuantizeParamsWrapperVariant(wrapper1),
+                                {}};
+  TensorWrapper tensor_wrapper1{0,
+                                QNN_TENSOR_TYPE_STATIC,
+                                QNN_DATATYPE_UFIXED_POINT_8,
+                                QuantizeParamsWrapperVariant(wrapper2),
+                                {}};
+  EXPECT_FALSE(tensor_wrapper0.IsPerTensorQuantWithOffsetDiff(tensor_wrapper1));
+  tensor_wrapper1.SetDataType(QNN_DATATYPE_SFIXED_POINT_8);
+  EXPECT_TRUE(tensor_wrapper0.IsPerTensorQuantWithOffsetDiff(tensor_wrapper1));
+}
+
+TEST(TensorWrapperTest, IsPerTensorQuantWithOffsetDiff16BitTest) {
+  constexpr int kSUFixed16OffsetDiff = 32768;
+  ScaleOffsetQuantizeParamsWrapper wrapper1(1, 0);
+  ScaleOffsetQuantizeParamsWrapper wrapper2(1, kSUFixed16OffsetDiff);
+  TensorWrapper tensor_wrapper0{0,
+                                QNN_TENSOR_TYPE_STATIC,
+                                QNN_DATATYPE_UFIXED_POINT_16,
+                                QuantizeParamsWrapperVariant(wrapper1),
+                                {}};
+  TensorWrapper tensor_wrapper1{0,
+                                QNN_TENSOR_TYPE_STATIC,
+                                QNN_DATATYPE_UFIXED_POINT_16,
+                                QuantizeParamsWrapperVariant(wrapper2),
+                                {}};
+  EXPECT_FALSE(tensor_wrapper0.IsPerTensorQuantWithOffsetDiff(tensor_wrapper1));
+  tensor_wrapper1.SetDataType(QNN_DATATYPE_SFIXED_POINT_16);
+  EXPECT_TRUE(tensor_wrapper0.IsPerTensorQuantWithOffsetDiff(tensor_wrapper1));
+}
+
+TEST(TensorWrapperTest, StaticTensorTest) {
+  TensorWrapper tensor_wrapper{0,
+                               QNN_TENSOR_TYPE_STATIC,
+                               QNN_DATATYPE_UNDEFINED,
+                               QuantizeParamsWrapperVariant(),
+                               {}};
+
+  EXPECT_TRUE(tensor_wrapper.IsTensorStatic());
+  EXPECT_FALSE(tensor_wrapper.IsSubgraphInput());
+  EXPECT_FALSE(tensor_wrapper.IsSubgraphOutput());
+}
+
+TEST(TensorWrapperTest, SubgraphInputTensorTest) {
+  TensorWrapper tensor_wrapper{0,
+                               QNN_TENSOR_TYPE_APP_WRITE,
+                               QNN_DATATYPE_UNDEFINED,
+                               QuantizeParamsWrapperVariant(),
+                               {}};
+
+  EXPECT_FALSE(tensor_wrapper.IsTensorStatic());
+  EXPECT_TRUE(tensor_wrapper.IsSubgraphInput());
+  EXPECT_FALSE(tensor_wrapper.IsSubgraphOutput());
+}
+
+TEST(TensorWrapperTest, SubgraphOutputTensorTest) {
+  TensorWrapper tensor_wrapper{0,
+                               QNN_TENSOR_TYPE_APP_READ,
+                               QNN_DATATYPE_UNDEFINED,
+                               QuantizeParamsWrapperVariant(),
+                               {}};
+
+  EXPECT_FALSE(tensor_wrapper.IsTensorStatic());
+  EXPECT_FALSE(tensor_wrapper.IsSubgraphInput());
+  EXPECT_TRUE(tensor_wrapper.IsSubgraphOutput());
+}
+
+TEST(TensorWrapperTest, GetStaticTensorDataNonStaticTest) {
+  std::vector<std::uint32_t> dummy_dims = {1, 1, 3};
+  ScaleOffsetQuantizeParamsWrapper q_param(1, 0);
+  TensorWrapper tensor_wrapper{0, QNN_TENSOR_TYPE_APP_WRITE,
+                               QNN_DATATYPE_UFIXED_POINT_8, q_param,
+                               dummy_dims};
+  EXPECT_FALSE(tensor_wrapper.GetStaticTensorData<std::uint8_t>().has_value());
+}
+
+TEST(TensorWrapperTest, GetStaticTensorDataTest) {
+  std::vector<std::uint32_t> dummy_dims = {1, 1, 3};
+  ScaleOffsetQuantizeParamsWrapper q_param(1, 0);
+  TensorWrapper tensor_wrapper{0, QNN_TENSOR_TYPE_STATIC,
+                               QNN_DATATYPE_UFIXED_POINT_8, q_param,
+                               dummy_dims};
+
+  EXPECT_FALSE(tensor_wrapper.GetStaticTensorData<float>().has_value());
+  EXPECT_FALSE(tensor_wrapper.GetStaticTensorData<std::int8_t>().has_value());
+  EXPECT_FALSE(tensor_wrapper.GetStaticTensorData<std::uint8_t>().has_value());
+  std::vector<std::uint8_t> data = {1, 2, 3};
+  tensor_wrapper.SetTensorData<std::uint8_t>(
+      absl::MakeSpan(data.data(), data.size()));
+  const auto tensor_data =
+      *(tensor_wrapper.GetStaticTensorData<std::uint8_t>());
+  for (size_t i = 0; i < data.size(); i++) {
+    EXPECT_EQ(tensor_data[i], data[i]);
+  }
+}
+}  // namespace
+}  // namespace qnn


### PR DESCRIPTION
# What

1. Refactor tensor wrapper

    - Safer tensor data getter and setter.

2. Add wrapper tests.
3. Fix rms norm builder
    - Change 0 beta tensor type to float32 for float32 input and uint8 for other input data types. See op support types [here](https://docs.qualcomm.com/bundle/publicresource/topics/80-63442-50/HtpOpDefSupplement.html#rmsnorm). 

# Tests
`qnn_compiler_plugin_test`
```
[----------] Global test environment tear-down
[==========] 99 tests from 5 test suites ran. (3995 ms total)
[  PASSED  ] 99 tests.
```