### PR TITLE
[DO NOT MERGE] Load Large Model Failed

### DIFF
--- a/tensorflow/lite/experimental/litert/c/litert_model_test.cc
+++ b/tensorflow/lite/experimental/litert/c/litert_model_test.cc
@@ -50,7 +50,7 @@ TEST(LiteRtWeightsTest, GetNullWeights) {
 
 TEST(LiteRtWeightsTest, GetWeights) {
   LiteRtWeightsT weights;
-  detail::SetTflBuffer(weights, MakeTflBuffer({1, 2, 3}));
+  detail::SetTflBuffer(weights, MakeTflBuffer({1, 2, 3}), {});
 
   const void* addr;
   size_t size;

--- a/tensorflow/lite/experimental/litert/core/model/BUILD
+++ b/tensorflow/lite/experimental/litert/core/model/BUILD
@@ -79,9 +79,9 @@ cc_library(
         "//tensorflow/lite/experimental/litert/cc:litert_buffer_ref",
         "//tensorflow/lite/experimental/litert/cc:litert_expected",
         "//tensorflow/lite/experimental/litert/cc:litert_macros",
+        "//tensorflow/lite/experimental/litert/core:filesystem",
         "//tensorflow/lite/experimental/litert/core/util:flatbuffer_tools",
         "//tensorflow/lite/schema:schema_fbs",
-        "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/strings:string_view",
     ],
 )
@@ -125,6 +125,7 @@ cc_library(
     deps = [
         ":litert_to_flatbuffer",
         ":model",
+        "//tensorflow/compiler/mlir/lite/schema:schema_fbs_with_mutable",
         "//tensorflow/lite/experimental/litert/c:litert_common",
         "//tensorflow/lite/experimental/litert/c:litert_logging",
         "//tensorflow/lite/experimental/litert/cc:litert_buffer_ref",
@@ -133,6 +134,7 @@ cc_library(
         "//tensorflow/lite/experimental/litert/core:byte_code_util",
         "//tensorflow/lite/experimental/litert/core/util:flatbuffer_tools",
         "//tensorflow/lite/schema:schema_fbs",
+        "//tensorflow/lite/schema:schema_fbs_with_mutable",
         "@com_google_absl//absl/container:flat_hash_map",
     ],
 )

--- a/tensorflow/lite/experimental/litert/core/model/model.cc
+++ b/tensorflow/lite/experimental/litert/core/model/model.cc
@@ -14,6 +14,8 @@
 
 #include "tensorflow/lite/experimental/litert/core/model/model.h"
 
+#include <sys/types.h>
+
 #include <algorithm>
 #include <cstdint>
 #include <string>
@@ -30,6 +32,7 @@
 #include "tensorflow/lite/experimental/litert/core/util/flatbuffer_tools.h"
 
 using ::litert::BufferRef;
+using ::litert::OwningBufferRef;
 using ::litert::internal::TflBuffer;
 using ::litert::internal::TflBufferPtr;
 using ::litert::internal::TflOpCode;
@@ -111,8 +114,10 @@ TflBufferPtr TakeTflBuffer(LiteRtWeightsT& litert_weights) {
   return std::move(litert_weights.tfl_buf_);
 }
 
-void SetTflBuffer(LiteRtWeightsT& litert_weights, TflBufferPtr tfl_buffer) {
+void SetTflBuffer(LiteRtWeightsT& litert_weights, TflBufferPtr tfl_buffer,
+                  BufferRef<uint8_t> flatbuffer) {
   litert_weights.tfl_buf_ = std::move(tfl_buffer);
+  litert_weights.flatbuffer_ = flatbuffer;
 }
 
 const std::vector<TflOpCodePtr>& GetTflOpCodes(
@@ -126,7 +131,8 @@ std::vector<TflOpCodePtr>&& TakeTflOpCodes(LiteRtModelT& litert_model) {
 
 void SetTflInitFlatbuffer(LiteRtModelT& litert_model,
                           BufferRef<uint8_t> init_flatbuffer) {
-  litert_model.tfl_init_flatbuffer_ = init_flatbuffer;
+  litert_model.tfl_init_flatbuffer_ =
+      OwningBufferRef<uint8_t>(init_flatbuffer.Data(), init_flatbuffer.Size());
 }
 
 BufferRef<uint8_t> GetTflInitFlatbuffer(const LiteRtModelT& litert_model) {

--- a/tensorflow/lite/experimental/litert/core/model/model_file_test.cc
+++ b/tensorflow/lite/experimental/litert/core/model/model_file_test.cc
@@ -723,5 +723,13 @@ INSTANTIATE_TEST_SUITE_P(ModelSerializeQuantizedOpCheckTest,
                          ModelSerializeOpCheckTest,
                          ::testing::ValuesIn(kAllQModels));
 
+TEST(LoadModel, Load) {
+ const std::string model_path =
+     "/local/mnt/workspace/chunhsuehlee/LiteRT/models_google/gemma2_float32_seq512_ekv512.tflite";
+ auto model = litert::testing::LoadTestFileModel(model_path);
+ auto signatures = model.GetSignatures();
+ ASSERT_EQ(signatures->size(), 1);
+}
+
 }  // namespace
 }  // namespace litert::internal

--- a/tensorflow/lite/experimental/litert/core/model/model_graph.cc
+++ b/tensorflow/lite/experimental/litert/core/model/model_graph.cc
@@ -41,7 +41,13 @@ void CloneTo(const LiteRtTensorT& src, LiteRtTensorT& dest) {
   dest.SetQarams(src.Qparams());
   dest.SetType(src.Type());
   // TODO: b/383906683 Avoid copying for better performance.
-  dest.Weights().SetFromBuf(src.Weights().Buf());
+  if (src.Weights().HasWeights()) {
+    if (src.Weights().IsAppended()) {
+      dest.Weights().SetFromWeights(src.Weights());
+    } else {
+      dest.Weights().SetFromBuf(src.Weights().Buf());
+    }
+  }
 }
 
 void CloneTo(const LiteRtOpT& src, LiteRtOpT& dest) {

--- a/tensorflow/lite/experimental/litert/core/model/model_load.cc
+++ b/tensorflow/lite/experimental/litert/core/model/model_load.cc
@@ -28,6 +28,7 @@
 #include "tensorflow/lite/experimental/litert/cc/litert_buffer_ref.h"
 #include "tensorflow/lite/experimental/litert/cc/litert_expected.h"
 #include "tensorflow/lite/experimental/litert/cc/litert_macros.h"
+#include "tensorflow/lite/experimental/litert/core/filesystem.h"
 #include "tensorflow/lite/experimental/litert/core/model/flatbuffer_to_litert.h"
 #include "tensorflow/lite/experimental/litert/core/model/model.h"
 #include "tensorflow/lite/experimental/litert/core/model/model_graph.h"
@@ -40,13 +41,16 @@ namespace {
 // Provides a view of model-level resources when constructing litert graph.
 class FlatbufferContext {
  public:
-  explicit FlatbufferContext(TflModel& tfl_model) : tfl_model_(tfl_model) {}
+  explicit FlatbufferContext(TflModel& tfl_model, BufferRef<uint8_t> flatbuffer)
+      : tfl_model_(tfl_model), flatbuffer_(flatbuffer) {}
 
   void SetOpCode(LiteRtOpT& litert_op, uint32_t ind) {
     auto tfl_op_code = GetTflOpCode(tfl_model_, ind);
     litert_op.SetOpCode(static_cast<LiteRtOpCode>(*tfl_op_code));
     detail::SetTflOpCodeInd(litert_op, ind);
   }
+
+  BufferRef<uint8_t> GetFlatbufferStart() { return flatbuffer_; }
 
   // Take ownership of the tfl buffer under the given index if it exists.
   Expected<TflBufferPtr> TakeTflBuffer(uint32_t ind) {
@@ -61,6 +65,7 @@ class FlatbufferContext {
 
  private:
   TflModel& tfl_model_;
+  BufferRef<uint8_t> flatbuffer_;
 };
 
 LiteRtStatus UnpackOp(FlatbufferContext& context, LiteRtSubgraphT& parent,
@@ -123,12 +128,8 @@ LiteRtStatus UnpackTensor(FlatbufferContext& context, TflTensorPtr tfl_tensor,
       return buffer.Error().Status();
     }
 
-    if (buffer->get()->offset != 0) {
-      // TODO: b/365299994 - Support buffer with offset.
-      LITERT_LOG(LITERT_ERROR, "Buffers with offset not yet supported.");
-      return kLiteRtStatusErrorUnsupported;
-    }
-    detail::SetTflBuffer(litert_tensor.Weights(), std::move(*buffer));
+    detail::SetTflBuffer(litert_tensor.Weights(), std::move(*buffer),
+                         context.GetFlatbufferStart());
   }
 
   // TENSOR TYPE
@@ -277,9 +278,12 @@ LiteRtStatus UnpackMetadata(FlatbufferContext& context,
   return kLiteRtStatusOk;
 }
 
-Expected<LiteRtModelT::Ptr> UnpackModel(TflModelPtr tfl_model) {
+Expected<LiteRtModelT::Ptr> UnpackModel(TflModelPtr tfl_model,
+                                        BufferRef<uint8_t> flatbuffer) {
   auto litert_model = std::make_unique<LiteRtModelT>();
-  FlatbufferContext context(*tfl_model);
+  detail::SetTflInitFlatbuffer(*litert_model, flatbuffer);
+  FlatbufferContext context(*tfl_model,
+                            detail::GetTflInitFlatbuffer(*litert_model));
 
   for (auto& tfl_subgraph : tfl_model->subgraphs) {
     LITERT_EXPECT_OK(UnpackSubgraph(context, std::move(tfl_subgraph),
@@ -300,20 +304,24 @@ Expected<LiteRtModelT::Ptr> LoadModelFromBuffer(BufferRef<uint8_t> buffer) {
   if (!flatbuffer) {
     return flatbuffer.Error();
   }
-  auto litert_model = UnpackModel(flatbuffer->get()->Unpack());
-  if (litert_model) {
-    // Save the original FB pointer to use it later on CompiledModel.
-    detail::SetTflInitFlatbuffer(**litert_model, buffer);
-  }
+  auto litert_model = UnpackModel(flatbuffer->get()->Unpack(), buffer);
+  // if (litert_model) {
+  //   // Save the original FB pointer to use it later on CompiledModel.
+  //   detail::SetTflInitFlatbuffer(**litert_model, buffer);
+  // }
   return litert_model;
 }
 
 Expected<LiteRtModelT::Ptr> LoadModelFromFile(absl::string_view filename) {
-  auto flatbuffer = FlatbufferWrapper::CreateFromTflFile(filename);
+  auto buf = LoadBinaryFile(filename);
+  if (!buf) {
+    return buf.Error();
+  }
+  auto flatbuffer = FlatbufferWrapper::CreateFromBuffer(*buf);
   if (!flatbuffer) {
     return flatbuffer.Error();
   }
-  return UnpackModel(flatbuffer->get()->Unpack());
+  return UnpackModel(flatbuffer->get()->Unpack(), *buf);
 }
 
 }  // namespace litert::internal

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/compiler/IR/qnn_tensor.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/compiler/IR/qnn_tensor.cc
@@ -41,15 +41,15 @@ LiteRtStatus LegalizeShapeInfo(const litert::Layout& src, Qnn_Tensor_t& dest) {
     dest.v2.dimensions = new uint32_t[1];
     dest.v2.dimensions[0] = 1;
     return kLiteRtStatusOk;
-  }
+  } else {
+    dest.v2.dimensions = new uint32_t[dest.v2.rank];
+    for (int i = 0; i < dest.v2.rank; ++i) {
+      // const auto src_dim = src.Dimensions()[i];
+      // LITERT_ENSURE(src_dim >= 1, kLiteRtStatusErrorInvalidArgument,
+      //               "Cannot pass dim < 1 to QNN Tensor.");
 
-  dest.v2.dimensions = new uint32_t[dest.v2.rank];
-  for (int i = 0; i < dest.v2.rank; ++i) {
-    const auto src_dim = src.Dimensions()[i];
-    LITERT_ENSURE(src_dim >= 1, kLiteRtStatusErrorInvalidArgument,
-                  "Cannot pass dim < 1 to QNN Tensor.");
-
-    dest.v2.dimensions[i] = src.Dimensions()[i];
+      dest.v2.dimensions[i] = src.Dimensions()[i];
+    }
   }
   return kLiteRtStatusOk;
 }


### PR DESCRIPTION
### Description
I found out that we met this error due to the ASSERT only in debug build (Release build could PASS).
`//tensorflow/bazel-out/k8-dbg/bin/external/flatbuffers/_virtual_includes/runtime_cc/flatbuffers/verifier.h#L47`. 
![image](https://github.com/user-attachments/assets/4e2b8fa8-755f-4b64-b3ee-19f45b0c3545)
`FLATBUFFERS_MAX_BUFFER_SIZE` is set to 2GB-1

### Build
`bazel build -c opt --cxxopt=--std=c++20 //tensorflow/lite/experimental/litert/core/model:model_file_test --compilation_mode=dbg
`

### Run
`./bazel-bin/tensorflow/lite/experimental/litert/core/model/model_file_test --gtest_filter=*LoadModel*`
