### PR TITLE
Qualcomm AI Engine Direct - Cast int8 embedding lookup table to int16

### DIFF
--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/embedding_lookup_op_builder.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/embedding_lookup_op_builder.cc
@@ -1,21 +1,56 @@
-// Copyright (c) Qualcomm Innovation Center, Inc.
-// All Rights Reserved.
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 #include "tensorflow/lite/experimental/litert/vendors/qualcomm/core/builders/embedding_lookup_op_builder.h"
 
+#include <numeric>
+
 namespace qnn {
+namespace {
+constexpr int kTableIdx = 1;
+constexpr int kIndicesIdx = 0;
+constexpr int kOutputIdx = 0;
+}  // namespace
 
 std::vector<OpWrapper> BuildEmbeddingLookupOp(
     TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
     const std::vector<TensorWrapperRef>& outputs) {
   std::vector<OpWrapper> res;
 
+  TensorWrapper& table_tensor = inputs[kTableIdx];
+  TensorWrapper& indices_tensor = inputs[kIndicesIdx];
+  TensorWrapper& output_tensor = outputs[kOutputIdx];
+
   auto& gather_op = CreateOpWrapper(res, QNN_OP_GATHER);
-  gather_op.AddInputTensor(inputs[1]);
-  gather_op.AddInputTensor(inputs[0]);
-  for (const auto& output : outputs) {
-    gather_op.AddOutputTensor(output);
+  // Case: QInt8 table with QInt16 output
+  if (table_tensor.IsQuant8() && output_tensor.IsQuant16()) {
+    QNN_LOG_WARNING(
+        "The data type of embedding lookup table is int8, but output data type "
+        "is int16. Int8 table will be cast to int16.");
+    std::vector<std::int16_t> int16_data;
+    size_t data_len =
+        std::accumulate(table_tensor.GetDims().begin(),
+                        table_tensor.GetDims().end(), 1, std::multiplies<>());
+    // TODO: do not cast
+    auto* int8_data = reinterpret_cast<const std::int8_t*>(
+        table_tensor.GetStaticTensorData());
+    for (int i = 0; i < data_len; ++i) {
+      int16_data.emplace_back(static_cast<std::int16_t>(int8_data[i]));
+    }
+
+    TensorWrapper& int16_table_tensor = tensor_pool.CreateStaticTensor(
+        output_tensor.GetDataType(), table_tensor.GetQuantParams(),
+        table_tensor.GetDims(),
+        sizeof(decltype(int16_data)::value_type) * int16_data.size(),
+        reinterpret_cast<void*>(int16_data.data()));
+
+    gather_op.AddInputTensor(int16_table_tensor);
+  } else {
+    gather_op.AddInputTensor(table_tensor);
   }
+
+  gather_op.AddInputTensor(indices_tensor);
+  gather_op.AddOutputTensor(output_tensor);
   gather_op.AddScalarParam<std::int32_t>(QNN_OP_GATHER_PARAM_AXIS, 0);
   return res;
 }

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/utils/log_android.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/utils/log_android.cc
@@ -27,7 +27,7 @@ int GetPlatformSeverity(LiteRtQnnLogLevel severity) {
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
 FILE* QNNLogger::log_file_pointer_ = stderr;
-LiteRtQnnLogLevel QNNLogger::log_level_ = kLogOff;
+LiteRtQnnLogLevel QNNLogger::log_level_ = kLogLevelInfo;
 // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
 void QNNLogger::SetLogFilePointer(FILE* fp) { log_file_pointer_ = fp; }
 void QNNLogger::SetLogLevel(LiteRtQnnLogLevel log_level) {

--- a/tensorflow/lite/experimental/litert/vendors/qualcomm/core/utils/log_default.cc
+++ b/tensorflow/lite/experimental/litert/vendors/qualcomm/core/utils/log_default.cc
@@ -9,7 +9,7 @@ namespace qnn {
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
 FILE* QNNLogger::log_file_pointer_ = stderr;
-LiteRtQnnLogLevel QNNLogger::log_level_ = kLogOff;
+LiteRtQnnLogLevel QNNLogger::log_level_ = kLogLevelInfo;
 // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
 void QNNLogger::SetLogFilePointer(FILE* fp) { log_file_pointer_ = fp; }
 void QNNLogger::SetLogLevel(LiteRtQnnLogLevel log_level) {


### PR DESCRIPTION
# What
- Some models contain embedding lookup ops with int8 table and int16 output. Provided a solution.
- Set default qualcomm vendor logger to INFO.

# Tests
Passed `qnn_compiler_plugin_test`
```
[----------] Global test environment tear-down
[==========] 97 tests from 5 test suites ran. (3450 ms total)
[  PASSED  ] 97 tests.
```